### PR TITLE
Adjusted Heroku client build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "concurrently \"cd server && yarn start\" \"cd client && yarn run deploy\"",
+    "start": "concurrently \"cd server && yarn start\"",
     "build": "yarn start",
-    "postinstall": "cd client && yarn install --production=false && cd ../server && yarn install --production=false"
+    "postinstall": "cd client && yarn install --production=false && yarn run deploy && cd ../server && yarn install --production=false"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Moved `yarn run deploy` (client-building step) to the post-install step from the start step so that it doesn't rebuild on each restart