### PR TITLE
Add Question support for Split View

### DIFF
--- a/client/src/components/includes/AddQuestion.tsx
+++ b/client/src/components/includes/AddQuestion.tsx
@@ -221,7 +221,6 @@ class AddQuestion extends React.Component {
 
         return (
             <div className="AddQuestion">
-                <hr />
                 <div className="queueHeader">
                     <p className="xbutton" onClick={this.handleXClick}><Icon name="close" /></p>
                     <p className="title">Join The Queue</p>

--- a/client/src/components/includes/ConnectedQuestionView.tsx
+++ b/client/src/components/includes/ConnectedQuestionView.tsx
@@ -1,0 +1,126 @@
+import * as React from 'react';
+
+import gql from 'graphql-tag';
+import { graphql } from 'react-apollo';
+import { ChildProps } from 'react-apollo';
+import AddQuestion from '../includes/AddQuestion';
+import { Loader } from 'semantic-ui-react';
+
+const QUERY = gql`
+    query FindTagsBySessionId($sessionId: Int!) {
+        allSessions(condition: {sessionId: $sessionId}) {
+            nodes {
+                sessionSeryBySessionSeriesId {
+                    courseByCourseId {
+                        tagsByCourseId {
+                            nodes {
+                                tagId
+                                name
+                                level
+                                tagRelationsByChildId {
+                                    nodes {
+                                        parentId
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+`;
+
+type InputProps = {
+    sessionId: number,
+    courseId: number,
+    data: {
+        loading: boolean,
+        allSessions?: {
+            nodes: [{
+                sessionSeryBySessionSeriesId: {
+                    courseByCourseId: {
+                        tagsByCourseId: {
+                            nodes: [{
+                                tagId: number,
+                                name: string,
+                                level: number
+                                tagRelationsByChildId: {
+                                    nodes: [{
+                                        parentId: number
+                                    }]
+                                }
+                            }]
+                        }
+                    }
+                }
+
+            }],
+        },
+    },
+};
+
+const withData = graphql<Response, InputProps>(QUERY, {
+    options: ({ sessionId }) => ({
+        variables: { sessionId: sessionId }
+    })
+});
+
+class ConnectedQuestionView extends React.Component<ChildProps<InputProps, Response>, {}> {
+    render() {
+        const imageURL =
+            'https://i2.wp.com/puppypassionn.org/wp-content/uploads/2017/12/img_0881.jpg?resize=256%2C256&ssl=1';
+        const { loading } = this.props.data;
+
+        if (loading) {
+            return <Loader active={true} content={'Loading'} />;
+        }
+
+        if (this.props.data.allSessions !== undefined) {
+            var series = this.props.data.allSessions.nodes[0].sessionSeryBySessionSeriesId;
+            var tags = series ? series.courseByCourseId.tagsByCourseId.nodes : [];
+
+            var primaryTagNames = [];
+            var secondaryTagNames = [];
+            var primaryTagNamesIds = [];
+            var secondaryTagNamesIds = [];
+            var secondaryTagParentIds = [];
+            for (var i = 0; i < tags.length; i++) {
+                if (tags[i].level === 1) {
+                    primaryTagNames.push(tags[i].name);
+                    primaryTagNamesIds.push(tags[i].tagId);
+                }
+                if (tags[i].level === 2) {
+                    secondaryTagNames.push(tags[i].name);
+                    secondaryTagNamesIds.push(tags[i].tagId);
+                    secondaryTagParentIds.push(tags[i].tagRelationsByChildId.nodes[0].parentId);
+                }
+            }
+
+            return (
+                <div className="QuestionView">
+                    <AddQuestion
+                        taName="Sangwoo Kim"
+                        taPicture={imageURL}
+                        primaryTags={primaryTagNames}
+                        secondaryTags={secondaryTagNames}
+                        primaryTagsIds={primaryTagNamesIds}
+                        secondaryTagsIds={secondaryTagNamesIds}
+                        secondaryTagParentIds={secondaryTagParentIds}
+                        sessionId={this.props.sessionId}
+                        courseId={this.props.courseId}
+                    />
+                </div>
+            );
+        }
+
+        return (
+            <div className="QuestionView">
+                Error
+            </div>
+        );
+
+    }
+}
+
+export default withData(ConnectedQuestionView);

--- a/client/src/styles/SplitView.less
+++ b/client/src/styles/SplitView.less
@@ -41,11 +41,49 @@ section .SessionJoinButton {
     padding-top: 46vh;
 }
 
+.modal {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 1000px;
+    max-width: 100%;
+    height: 600px;
+    max-height: 100%;
+    z-index: 9999;
+    border-radius: 15px;
+    overflow: hidden;
+}
+
+.modalShade {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 3;
+    background-color: rgba(112, 112, 112, 0.8);
+}
+
 @media only screen and (max-width: 800px) {
     aside.CalendarView, section.StudentSessionView {
         width: 100%;
         position: relative;
         height: 100%;
         left: 0;
+    }
+
+    .modal {
+        border-radius: 0;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        transform: none;
+        height: 100%;
+    }
+
+    .modalShade {
+        display: none;
     }
 }


### PR DESCRIPTION
I added support for the AddQuestion modal flow from Zeplin. The design isn’t in full compliance, but it’s pretty close for now. The mobile fallback does not display as a modal but a full view.