### PR TITLE
Authentication Patch

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -294,7 +294,7 @@ All the fields of the newly-inserted row from the [questions](#questions) table
 #### api\_find\_or\_create\_user
 
 ##### Description
-Given the details of a user who has just logged in using Google, this function will find and return the user's existing details in the [users](#users) table. If it is a new user, a new row is inserted into [users](#users) for them. This is meant to be used during the login process, right after the user has successfully logged in via Google.
+Given the details of a user who has just logged in using Google, this function will find and return the user's existing details in the [users](#users) table. If it is a new user, a new row is inserted into [users](#users) for them. This is meant to be used during the login process, right after the user has successfully logged in via Google. Note that only a user that sends a JWT in the Authorization header containing the claim userId=-1 will be allowed to make this call successfully. The server is the only entity that has access to the secret, so only the server is allowed to make this call (after successful Google login); users will not be able to mock the identity of other users by calling this function directly.
 
 ##### Parameters
 - \_email (text): the full email address of the user who logged in
@@ -355,6 +355,7 @@ Trigger functions are prefixed by 'trigger' and **should never be called directl
 |Trigger Function|Table|Condition|Description|
 |---|---|---|---|
 trigger\_before\_update\_question|[questions](#questions)|before update|injects answerer\_id and time\_addressed|
+trigger\_after\_insert\_course|[courses](#courses)|after insert|adds every existing user as a student of the inserted course in [course-users](#course-users)|
 
 ## Types
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -29,7 +29,7 @@ var sessionOptions = {
     name: 'queue-me-in-cookie',
     maxAge: 7 /* days */ * 24 /* hours */ * 60 /* minutes */ * 60 /* seconds */ * 1000 /* milliseconds */,
     secure: false,
-    secret: (process.env.OH_SESSION_SECRET || "<veWHM#Q9a<k8^")
+    secret: (process.env.OH_SESSION_SECRET || "insecure")
 }
 
 if (app.get('env') === 'production') {
@@ -82,8 +82,13 @@ passport.use(new GoogleStrategy(
             '","variables":"' +
             variablesString +
             '"}';
+
+        const serverJwt = jwt.sign({ userId: -1 }, (process.env.OH_JWT_SECRET || "insecure"), {
+            expiresIn: '30s',
+            audience: 'postgraphql',
+        });
         request.post({
-            headers: { 'content-type': 'application/json' },
+            headers: { 'content-type': 'application/json', 'Authorization': `Bearer ${serverJwt}` },
             url: ownBaseUrl + '/__gql/graphql',
             body: bodyContent
         }, function (error, response, body) {
@@ -93,7 +98,7 @@ passport.use(new GoogleStrategy(
 ))
 
 passport.serializeUser(function (user: any, done) {
-    var token = jwt.sign(user, (process.env.OH_JWT_SECRET || "<veWHM#Q9a<k8^"), {
+    var token = jwt.sign(user, (process.env.OH_JWT_SECRET || "insecure"), {
         expiresIn: '1w',
         audience: 'postgraphql',
     });
@@ -155,7 +160,7 @@ app.use(function (req, res, next) {
             req.headers.authorization = `Bearer ${req.user}`;
         } else {
             if (options.fakeuserid) {
-                const fakeJwt = jwt.sign({ userId: options.fakeuserid }, (process.env.OH_JWT_SECRET || "<veWHM#Q9a<k8^"), {
+                const fakeJwt = jwt.sign({ userId: options.fakeuserid }, (process.env.OH_JWT_SECRET || "insecure"), {
                     expiresIn: '1y',
                     audience: 'postgraphql',
                 });
@@ -170,7 +175,7 @@ app.use(postgraphql(process.env.DATABASE_URL || 'postgres://localhost:5432', {
     graphiql: true,
     graphqlRoute: '/__gql/graphql',
     graphiqlRoute: '/__gql/graphiql',
-    jwtSecret: (process.env.OH_JWT_SECRET || "<veWHM#Q9a<k8^"),
+    jwtSecret: (process.env.OH_JWT_SECRET || "insecure"),
     jwtPgTypeIdentifier: 'public.jwt_token'
 }));
 


### PR DESCRIPTION
- Fixes the authentication flaw in #61 by only allowing the server to call `api_find_or_create_user`
- Adds a database trigger to the courses table, which adds every existing user as a student whenever a new course is inserted
- Updated database documentation with these changes