### PR TITLE
Add routing forwarding and fix safari bug

### DIFF
--- a/client/src/components/includes/CalendarView.tsx
+++ b/client/src/components/includes/CalendarView.tsx
@@ -159,45 +159,43 @@ class CalendarView extends React.Component {
         const todayIndex = ((selectedDate.getDay() - 1) + 7) % 7;
 
         return (
-            <section className="StudentSessionView">
-                <DaySessionDataQuery
-                    query={GET_CALENDAR_DATA}
-                    variables={{
-                        beginTime: selectedDate,
-                        endTime: new Date(this.state.selectedDateEpoch + ONE_DAY),
-                        courseId: this.props.courseId
-                    }}
-                >
-                    {({ loading, data, error }) => {
-                        if (error) { return <h1>ERROR</h1>; }
-                        if (!data) { return <div>Loading...</div>; }
-                        return (
-                            <aside className="CalendarView">
-                                <div className="Header">
-                                    <CalendarHeader
-                                        currentCourseCode={
-                                            data.courseByCourseId && data.courseByCourseId.code || 'Loading'}
-                                        isTa={data.apiGetCurrentUser && data.apiGetCurrentUser.nodes[0].
-                                            courseUsersByUserId.nodes[0].role !== 'student'}
-                                    />
-                                    <CalendarWeekSelect handleClick={this.handleWeekClick} />
-                                </div>
-                                <CalendarDateSelect
-                                    dateList={dates}
-                                    handleClick={this.handleDateClick}
-                                    selectedIndex={todayIndex}
+            <DaySessionDataQuery
+                query={GET_CALENDAR_DATA}
+                variables={{
+                    beginTime: selectedDate,
+                    endTime: new Date(this.state.selectedDateEpoch + ONE_DAY),
+                    courseId: this.props.courseId
+                }}
+            >
+                {({ loading, data, error }) => {
+                    if (error) { return <h1>ERROR</h1>; }
+                    if (!data) { return <div>Loading...</div>; }
+                    return (
+                        <aside className="CalendarView">
+                            <div className="Header">
+                                <CalendarHeader
+                                    currentCourseCode={
+                                        data.courseByCourseId && data.courseByCourseId.code || 'Loading'}
+                                    isTa={data.apiGetCurrentUser && data.apiGetCurrentUser.nodes[0].
+                                        courseUsersByUserId.nodes[0].role !== 'student'}
                                 />
-                                <CalendarSessions
-                                    loading={loading}
-                                    sessions={data.apiGetSessions ? data.apiGetSessions.nodes : null}
-                                    callback={this.props.sessionCallback}
-                                    activeSessionId={this.props.sessionId}
-                                />
-                            </aside>
-                        );
-                    }}
-                </DaySessionDataQuery>
-            </section>
+                                <CalendarWeekSelect handleClick={this.handleWeekClick} />
+                            </div>
+                            <CalendarDateSelect
+                                dateList={dates}
+                                handleClick={this.handleDateClick}
+                                selectedIndex={todayIndex}
+                            />
+                            <CalendarSessions
+                                loading={loading}
+                                sessions={data.apiGetSessions ? data.apiGetSessions.nodes : null}
+                                callback={this.props.sessionCallback}
+                                activeSessionId={this.props.sessionId}
+                            />
+                        </aside>
+                    );
+                }}
+            </DaySessionDataQuery>
         );
     }
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -95,7 +95,7 @@ passport.use(new GoogleStrategy(
                 }
             }",
             "variables": "${variablesString}"
-        }`;
+        }`.replace(/\r?\n?/g, '');
 
         const serverJwt = jwt.sign({ userId: -1 }, (process.env.OH_JWT_SECRET || "insecure"), {
             expiresIn: '30s',

--- a/server/index.ts
+++ b/server/index.ts
@@ -195,6 +195,8 @@ app.use(postgraphql(process.env.DATABASE_URL || 'postgres://localhost:5432', {
 }));
 
 app.use(express.static('../client/build'));
+app.use('*', express.static('../client/build'));
+
 app.listen(process.env.PORT || 3001, () => {
     console.log("Now listening on port " + (process.env.PORT || 3001));
 });


### PR DESCRIPTION
Now you will no longer get the `Cannot GET /foobarroute` when the route doesn't exist and the service worker hasn't loaded, it just loads our react app. The two lines in index.ts seem necessary for some reason. 

Other than that, I just removed a redundant tag that was causing rendering errors in safari. (Accidentally introduced in my last PR)