### PR TITLE
Fix link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 by [Cornell Design & Tech Initiative](http://cornelldti.org)
 
 ## For Developers
-View the [setup documentation](./blob/master/docs/setup.md) for instructions on setting up and getting started with development!
+View the [setup documentation](https://github.com/cornell-dti/office-hours/blob/master/docs/setup.md) for instructions on setting up and getting started with development!
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 by [Cornell Design & Tech Initiative](http://cornelldti.org)
 
 ## For Developers
-View the [setup documentation](https://github.com/cornell-dti/office-hours/blob/master/docs/setup.md) for instructions on setting up and getting started with development!
+View the [setup documentation](./docs/setup.md) for instructions on setting up and getting started with development!
 
 ## Contributors
 


### PR DESCRIPTION
Link was broken before. Relative linking in GitHub is weird. Changed to absolute link.