### PR TITLE
Database Migration 0002: to fix AWS roles issue

### DIFF
--- a/server/database/migrations/0002_fix_aws_roles.sql
+++ b/server/database/migrations/0002_fix_aws_roles.sql
@@ -1,0 +1,1 @@
+GRANT backend TO postgres;


### PR DESCRIPTION
- Error in staging after deploying #74: could not `set role to backend` when the server started
- Fix: grant the default user (`postgres`) the permission to switch to the `backend` user
- Applied in staging and production; it is not required locally, and in fact does not appear in pg_dump (I'm guessing because `postgres` is already a superuser and does not need to be explicitly granted any permissions)