### PR TITLE
Front-end fixes before demos/launch

### DIFF
--- a/client/src/components/App.tsx
+++ b/client/src/components/App.tsx
@@ -8,6 +8,7 @@ import LoginView from './pages/LoginView';
 import ProfessorView from './pages/ProfessorView';
 import SplitView from './pages/SplitView';
 import ProfessorTagsView from './pages/ProfessorTagsView';
+import ProfessorDashboardView from './pages/ProfessorDashboardView';
 import { Analytics } from './includes/Analytics';
 import { Loader } from 'semantic-ui-react';
 
@@ -65,6 +66,11 @@ class App extends React.Component {
                         <PrivateRoute
                             path="/professor-tags/course/:courseId"
                             component={ProfessorTagsView}
+                            exact={true}
+                        />
+                        <PrivateRoute
+                            path="/professor-dashboard/course/:courseId"
+                            component={ProfessorDashboardView}
                             exact={true}
                         />
                         <PrivateRoute path="/professor/course/:courseId" component={ProfessorView} exact={true} />

--- a/client/src/components/includes/AddQuestion.tsx
+++ b/client/src/components/includes/AddQuestion.tsx
@@ -34,6 +34,7 @@ class AddQuestion extends React.Component {
         sessionId: number,
         courseId: number,
         callback: Function,
+        charLimit: number,
     };
 
     state: {
@@ -90,7 +91,7 @@ class AddQuestion extends React.Component {
     public handleUpdateQuestion = (event: React.ChangeEvent<HTMLTextAreaElement>): void => {
         const target = event.target as HTMLTextAreaElement;
         this.setState({
-            question: target.value.length <= 100 ? target.value : this.state.question,
+            question: target.value.length <= this.props.charLimit ? target.value : this.state.question,
             stage: target.value.length > 0 ? 40 : 30
         });
     }
@@ -114,6 +115,8 @@ class AddQuestion extends React.Component {
         if (this.state.redirect) {
             return <Redirect push={true} to={'/course/' + this.props.courseId + '/session/' + this.props.sessionId} />;
         }
+
+        var charsRemaining = this.props.charLimit - this.state.question.length;
 
         return (
             <div className="QuestionView">
@@ -164,7 +167,13 @@ class AddQuestion extends React.Component {
                         </div>
                         <hr />
                         <div className="tagsMiniContainer">
-                            <p className="header">Question</p>
+                            <p className="header">
+                                Question <span
+                                    className={'characterCount ' + (charsRemaining <= 0 ? 'warn' : '')}
+                                >
+                                    ({charsRemaining} character{charsRemaining !== 1 && 's'} left)
+                                </span>
+                            </p>
                             {this.state.stage >= 30 ?
                                 <textarea
                                     className="QuestionInput"

--- a/client/src/components/includes/AddQuestion.tsx
+++ b/client/src/components/includes/AddQuestion.tsx
@@ -71,9 +71,26 @@ class AddQuestion extends React.Component {
 
     public handleSecondarySelected = (deselected: boolean, id: number): void => {
         if (!deselected) {
+            // Temporary; needs to be factored out into a course setting
+            // Restrict to only one secondary tag (can be made shorter!):
+            var selectedTags = [];
+            for (var i = 0; i < this.state.selectedTags.length; i++) {
+                var keep = false;
+                for (var j = 0; j < this.props.tags.length; j++) {
+                    if (this.props.tags[j].tagId === this.state.selectedTags[i]) {
+                        keep = this.props.tags[j].level === 1;
+                        break;
+                    }
+                }
+                if (keep) {
+                    selectedTags.push(this.state.selectedTags[i]);
+                }
+            }
+            selectedTags.push(id);
             this.setState({
                 stage: this.state.question.length > 0 ? 40 : 30,
-                selectedTags: [...this.state.selectedTags, id]
+                // selectedTags: [...this.state.selectedTags, id]
+                selectedTags: selectedTags
             });
         } else if (this.state.selectedTags.length > 2) {
             this.setState({

--- a/client/src/components/includes/CalendarDaySelect.tsx
+++ b/client/src/components/includes/CalendarDaySelect.tsx
@@ -22,13 +22,21 @@ class CalendarDaySelect extends React.Component {
 
     constructor(props: {}) {
         super(props);
-        var week = new Date();
-        week.setHours(0, 0, 0, 0);
-        week.setTime(week.getTime() - (week.getDay() - 1) * ONE_DAY);
+        var week = new Date(); // now
+        week.setHours(0, 0, 0, 0); // beginning of today (00:00:00.000)
+        var daysSinceMonday = ((week.getDay() - 1) + 7) % 7;
+        week.setTime(week.getTime() - daysSinceMonday * ONE_DAY); // beginning of this week's Monday
         this.state = {
             selectedWeekEpoch: week.getTime(),
-            active: new Date().getDay() - 1 % 7   // index of currently selected date
+            active: daysSinceMonday   // index of currently selected date
         };
+    }
+
+    componentDidMount() {
+        // TODO: this is a super hacky way of getting around the bug where the current day's
+        // sessions do not get displayed on load. This simulates a click on the current day
+        // to refetch the query; if you see a way to fix this sustainably, please do so!
+        this.handleDateClick(this.state.active);
     }
 
     incrementWeek = (forward: boolean) => {

--- a/client/src/components/includes/CalendarHeader.tsx
+++ b/client/src/components/includes/CalendarHeader.tsx
@@ -4,6 +4,7 @@ class CalendarHeader extends React.Component {
     props: {
         currentCourseCode: string;
         isTa: boolean;
+        isProf: boolean;
         avatar: string | null;
     };
 
@@ -28,6 +29,7 @@ class CalendarHeader extends React.Component {
                         <span>
                             {this.props.currentCourseCode}
                             {this.props.isTa && <span className="TAMarker">TA</span>}
+                            {this.props.isProf && <span className="TAMarker Professor">PROF</span>}
                         </span>
                         {this.props.avatar &&
                             <img

--- a/client/src/components/includes/CalendarSessionCard.tsx
+++ b/client/src/components/includes/CalendarSessionCard.tsx
@@ -36,7 +36,9 @@ class CalendarSessionCard extends React.Component {
                 </div>
                 <div className="CalendarCard">
                     <div className="TA">
-                        {tas.map(ta => ta.userByUserId.computedName).join(' and ')}
+                        {tas.length > 2 ?
+                            tas.map(ta => ta.userByUserId.computedName).join(', ') :
+                            tas.map(ta => ta.userByUserId.computedName).join(' and ')}
                     </div>
                     <div className="Location">{session.building + ' ' + session.room}</div>
                     <div className="Queue">

--- a/client/src/components/includes/CalendarView.tsx
+++ b/client/src/components/includes/CalendarView.tsx
@@ -128,7 +128,9 @@ class CalendarView extends React.Component {
                                 currentCourseCode={
                                     data.courseByCourseId && data.courseByCourseId.code || 'Loading'}
                                 isTa={data.apiGetCurrentUser && data.apiGetCurrentUser.nodes[0]
-                                    .courseUsersByUserId.nodes[0].role !== 'student'}
+                                    .courseUsersByUserId.nodes[0].role === 'ta'}
+                                isProf={data.apiGetCurrentUser && data.apiGetCurrentUser.nodes[0]
+                                    .courseUsersByUserId.nodes[0].role === 'professor'}
                                 avatar={data.apiGetCurrentUser && data.apiGetCurrentUser.nodes[0].computedAvatar}
                             />
                             <CalendarDaySelect callback={this.handleDateClick} />

--- a/client/src/components/includes/CalendarWeekSelect.tsx
+++ b/client/src/components/includes/CalendarWeekSelect.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 const chevron = require('../../media/chevron.svg');
 
+const ONE_DAY = 24 /* hours */ * 60 /* minutes */ * 60 /* seconds */ * 1000 /* millis */;
+
 class CalendarWeekSelect extends React.Component {
+
     monthNames = ['January', 'February', 'March', 'April', 'May', 'June',
         'July', 'August', 'September', 'October', 'November', 'December'];
 
@@ -23,9 +26,8 @@ class CalendarWeekSelect extends React.Component {
         } else {
             var week = new Date();
             week.setHours(0, 0, 0, 0);
-            week.setTime(week.getTime() -
-                (week.getDay() - 1) /* days */ * 24 /* hours */
-                * 60 /* minutes */ * 60 /* seconds */ * 1000 /* millis */);
+            var daysSinceMonday = ((week.getDay() - 1) + 7) % 7;
+            week.setTime(week.getTime() - daysSinceMonday * ONE_DAY); // beginning of this week's Monday
             this.state = {
                 selectedWeekEpoch: week.getTime()
             };

--- a/client/src/components/includes/ConnectedQuestionView.tsx
+++ b/client/src/components/includes/ConnectedQuestionView.tsx
@@ -11,6 +11,7 @@ const QUERY = gql`
         allSessions(condition: {sessionId: $sessionId}) {
             nodes {
                 courseByCourseId {
+                    charLimit
                     tagsByCourseId {
                         nodes {
                             tagId
@@ -39,6 +40,7 @@ type InputProps = {
         allSessions?: {
             nodes: [{
                 courseByCourseId: {
+                    charLimit: number
                     tagsByCourseId: {
                         nodes: [AppTagRelations]
                     }
@@ -72,6 +74,7 @@ class ConnectedQuestionView extends React.Component<ChildProps<InputProps, Respo
                     sessionId={this.props.sessionId}
                     courseId={this.props.courseId}
                     callback={this.props.callback}
+                    charLimit={session.courseByCourseId.charLimit}
                 />
             );
         }

--- a/client/src/components/includes/ProfessorAddNew.tsx
+++ b/client/src/components/includes/ProfessorAddNew.tsx
@@ -63,7 +63,7 @@ class ProfessorAddNew extends React.Component {
                             cancelCallback={() => this.toggleEdit(false)}
                             refreshCallback={this.props.refreshCallback}
                             courseId={this.props.courseId}
-                            suggestedTagNames={['Debugging', 'Conceptual']}
+                            suggestedTagNames={['Conceptual', 'Coding']}
                         />
                     }
                 </div>

--- a/client/src/components/includes/ProfessorCalendarTable.tsx
+++ b/client/src/components/includes/ProfessorCalendarTable.tsx
@@ -43,6 +43,14 @@ class ProfessorCalendarTable extends React.Component {
         this.toggleEdit = this.toggleEdit.bind(this);
     }
 
+    componentWillReceiveProps(props: { data: { nodes: [AppSession] } }) {
+        var isExpanded: boolean[][] = [];
+        for (var i = 0; i < 7; i++) {
+            isExpanded.push(new Array<boolean>(props.data.nodes.length).fill(false));
+        }
+        this.setState({ isExpanded: isExpanded });
+    }
+
     toggleEdit(day: number, row: number, forceClose?: boolean) {
         var cDay = this.state.currentDay;
         var cRow = this.state.currentRow;

--- a/client/src/components/includes/ProfessorSidebar.tsx
+++ b/client/src/components/includes/ProfessorSidebar.tsx
@@ -37,13 +37,13 @@ class ProfessorSidebar extends React.Component {
                             <button className={selectedArray[0]}>
                                 <Icon name="setting" />
                                 Manage Hours
-                                </button>
+                            </button>
                         </Link>
                         <Link to={'/professor-tags/course/' + this.props.courseId}>
                             <button className={selectedArray[1]}>
                                 <Icon name="settings" />
                                 Manage Tags
-                                </button>
+                            </button>
                         </Link>
                         <Link to={'/professor-dashboard/course/' + this.props.courseId}>
                             <button className={selectedArray[2]}>

--- a/client/src/components/includes/ProfessorSidebar.tsx
+++ b/client/src/components/includes/ProfessorSidebar.tsx
@@ -9,7 +9,7 @@ class ProfessorSidebar extends React.Component {
     };
 
     render() {
-        var selectedArray: string[] = ['', '', '', ''];
+        var selectedArray: string[] = ['', '', ''];
         selectedArray[this.props.selected] = 'selected';
 
         return (
@@ -21,7 +21,7 @@ class ProfessorSidebar extends React.Component {
                             {/* <Icon name="dropdown" /> */}
                         </span>
                     </div>
-                    <div className="manage">
+                    {/* <div className="manage">
                         <button className={selectedArray[0]}>
                             <Icon name="users" />
                             People
@@ -31,19 +31,25 @@ class ProfessorSidebar extends React.Component {
                             Question
                             </button>
                     </div>
-                    <div className="divider" />
+                    <div className="divider" /> */}
                     <div className="actions">
                         <Link to={'/professor/course/' + this.props.courseId}>
-                            <button className={selectedArray[2]}>
+                            <button className={selectedArray[0]}>
                                 <Icon name="setting" />
                                 Manage Hours
                                 </button>
                         </Link>
                         <Link to={'/professor-tags/course/' + this.props.courseId}>
-                            <button className={selectedArray[3]}>
+                            <button className={selectedArray[1]}>
                                 <Icon name="settings" />
                                 Manage Tags
                                 </button>
+                        </Link>
+                        <Link to={'/professor-dashboard/course/' + this.props.courseId}>
+                            <button className={selectedArray[2]}>
+                                <Icon name="line graph" />
+                                Dashboard
+                            </button>
                         </Link>
                     </div>
                 </div>

--- a/client/src/components/includes/ProfessorTagInfo.tsx
+++ b/client/src/components/includes/ProfessorTagInfo.tsx
@@ -110,6 +110,9 @@ class ProfessorTagInfo extends React.Component {
     }
 
     handleNewTagEnter = (): void => {
+        if (this.state.newTagText.length === 0) {
+            return;
+        }
         var newTag: AppTag = {
             activated: true,
             level: 2,

--- a/client/src/components/includes/ProfessorTagInfo.tsx
+++ b/client/src/components/includes/ProfessorTagInfo.tsx
@@ -130,20 +130,42 @@ class ProfessorTagInfo extends React.Component {
         this.helperAddNewChildTag(newTag);
     }
 
+    // Sorry, this function is a bit of a mess. Please refactor it when you get spare time.
+    // There are many corner cases to handle, so definitely test your implementation a lot!
     handleRemoveChildTag = (index: number): void => {
+        // This case should never happen
         if (!this.state.tag.tagRelationsByParentId) {
             return;
         }
         var newChildTags = Object.assign({}, this.state.tag.tagRelationsByParentId);
         var filteredTags = newChildTags.nodes.filter((childTag) => childTag.tagByChildId.activated);
         var newChildTag = Object.assign({}, filteredTags[index]);
-        newChildTag = { tagByChildId: { ...newChildTag.tagByChildId, activated: false } };
+        newChildTag.tagByChildId = { ...newChildTag.tagByChildId, activated: false };
+        var allTags = newChildTags.nodes;
+        var newTags = [];
+        var shownIndex = -1;
+        var doneRemoving = false;
+        // Loop through all the tags (activated and not activated) to find the tag that was
+        // removed by the user. We want to match index to the index'th tag that is activated.
+        // For all other tags, we want to add their previous version; for the removed tag, we 
+        // add its previous version with activated = false (stored in newChildTag).
+        for (var i = 0; i < allTags.length; i++) {
+            if (allTags[i].tagByChildId.activated) {
+                shownIndex++;
+            }
+            if (shownIndex === index && !doneRemoving) {
+                newTags.push(newChildTag);
+                doneRemoving = true;
+            } else {
+                newTags.push(allTags[i]);
+            }
+        }
         this.setState({
             tag: {
                 ...this.state.tag,
                 tagRelationsByParentId:
                 {
-                    nodes: filteredTags.map((childTag, i) => i === index ? newChildTag : childTag)
+                    nodes: newTags
                 }
             }
         });
@@ -187,11 +209,10 @@ class ProfessorTagInfo extends React.Component {
         var childNames: string[] = [];
         var childActivateds: boolean[] = [];
         if (this.state.tag.tagRelationsByParentId) {
-            var filteredDeleted = this.state.tag.tagRelationsByParentId.nodes
-                .filter((childTag) => childTag.tagByChildId.tagId !== -1 || childTag.tagByChildId.activated);
-            childIds = filteredDeleted.map((childTag) => childTag.tagByChildId.tagId);
-            childNames = filteredDeleted.map((childTag) => childTag.tagByChildId.name);
-            childActivateds = filteredDeleted.map((childTag) => childTag.tagByChildId.activated);
+            var childTags = this.state.tag.tagRelationsByParentId.nodes;
+            childIds = childTags.map((childTag) => childTag.tagByChildId.tagId);
+            childNames = childTags.map((childTag) => childTag.tagByChildId.name);
+            childActivateds = childTags.map((childTag) => childTag.tagByChildId.activated);
         }
 
         EditAssignment({

--- a/client/src/components/includes/ProfessorTagsRow.tsx
+++ b/client/src/components/includes/ProfessorTagsRow.tsx
@@ -75,7 +75,7 @@ class ProfessorTagsRow extends React.Component {
                                     tag={row}
                                     courseId={this.props.courseId}
                                     refreshCallback={this.props.refreshCallback}
-                                    suggestedTagNames={['Debugging', 'Conceptual']}
+                                    suggestedTagNames={['Conceptual', 'Coding']}
                                 />
                             </td>
                         </tr>

--- a/client/src/components/includes/SessionInformationHeader.tsx
+++ b/client/src/components/includes/SessionInformationHeader.tsx
@@ -35,7 +35,9 @@ class SessionInformationHeader extends React.Component {
                             <Moment date={session.startTime} interval={0} format={'dddd, D MMM'} />
                         </p>
                         <p>Held by <span className="black">
-                            {tas.map(ta => ta.userByUserId.computedName).join(' and ')}
+                            {tas.length > 2 ?
+                                tas.map(ta => ta.userByUserId.computedName).join(', ') :
+                                tas.map(ta => ta.userByUserId.computedName).join(' and ')}
                         </span></p>
                     </div>
                     <div className="QueueWrap">

--- a/client/src/components/includes/SessionQuestion.tsx
+++ b/client/src/components/includes/SessionQuestion.tsx
@@ -29,13 +29,9 @@ class SessionQuestion extends React.Component {
     // on the question cards. 1 => "NOW", 2 => "2nd", 3 => "3rd", and so on.
     getDisplayText(index: number): string {
         index++;
-        if (index === 1) {
-            return 'NOW';
-        } else {
-            // Disclaimer: none of us wrote this one-line magic :)
-            // It is borrowed from https://stackoverflow.com/revisions/39466341/5
-            return index + ['st', 'nd', 'rd'][((index + 90) % 100 - 10) % 10 - 1] || index + 'th';
-        }
+        // Disclaimer: none of us wrote this one-line magic :)
+        // It is borrowed from https://stackoverflow.com/revisions/39466341/5
+        return index + ['st', 'nd', 'rd'][((index + 90) % 100 - 10) % 10 - 1] || index + 'th';
     }
 
     _onClick = (event: React.MouseEvent<HTMLElement>, updateQuestion: Function, status: string) => {
@@ -76,7 +72,10 @@ class SessionQuestion extends React.Component {
                     )}
                 </div>
                 <div className="BottomBar">
-                    <p className={'Order' + (this.props.index === 0 ? ' now' : '')}>
+                    {/* <p className={'Order' + (this.props.index === 0 ? ' now' : '')}>
+                        {this.getDisplayText(this.props.index)}
+                    </p> */}
+                    <p className="Order">
                         {this.getDisplayText(this.props.index)}
                     </p>
                     <p className="Time">{<Moment date={question.timeEntered} interval={0} format={'hh:mm A'} />}</p>

--- a/client/src/components/includes/SessionQuestion.tsx
+++ b/client/src/components/includes/SessionQuestion.tsx
@@ -21,7 +21,8 @@ class SessionQuestion extends React.Component {
         isTA: boolean,
         isMyQuestion: boolean,
         triggerUndo: Function,
-        refetch: Function
+        refetch: Function,
+        isPast: boolean,
     };
 
     // Given an index from [1..n], converts it to text that is displayed
@@ -105,7 +106,7 @@ class SessionQuestion extends React.Component {
                 }
                 <Mutation mutation={UPDATE_QUESTION} onCompleted={() => this.props.refetch()}>
                     {(updateQuestion) =>
-                        this.props.isMyQuestion &&
+                        this.props.isMyQuestion && !this.props.isPast &&
                         <div className="Buttons">
                             <hr />
                             <p

--- a/client/src/components/includes/SessionQuestionsContainer.tsx
+++ b/client/src/components/includes/SessionQuestionsContainer.tsx
@@ -34,7 +34,7 @@ class SessionQuestionsContainer extends React.Component {
                     <React.Fragment>
                         <div className="SessionClosedMessage">
                             You are holding a spot in another active queue.
-                            To join this queue instead, please retract your question from the other queue!
+                            To join this queue, please retract your question from the other queue!
                         </div>
                         <div className="SessionJoinButton disabled">
                             <p><Icon name="plus" /> Join the Queue</p>

--- a/client/src/components/includes/SessionQuestionsContainer.tsx
+++ b/client/src/components/includes/SessionQuestionsContainer.tsx
@@ -27,6 +27,11 @@ class SessionQuestionsContainer extends React.Component {
                         <p><Icon name="plus" /> Join the Queue</p>
                     </div>
                 }
+                {questions && questions.length > 0 && this.props.isPast &&
+                    <div className="SessionClosedMessage">
+                        This queue has closed and is no longer accepting new questions.
+                    </div>
+                }
                 {questions && myQuestion && myQuestion.length > 0 &&
                     <div className="User">
                         <p className="QuestionHeader">My Question</p>
@@ -38,6 +43,7 @@ class SessionQuestionsContainer extends React.Component {
                             isMyQuestion={true}
                             triggerUndo={this.props.triggerUndo}
                             refetch={this.props.refetch}
+                            isPast={this.props.isPast}
                         />
                         <p className="Queue">Queue</p>
                     </div>
@@ -52,6 +58,7 @@ class SessionQuestionsContainer extends React.Component {
                             isMyQuestion={question.userByAskerId.userId === this.props.myUserId}
                             triggerUndo={this.props.triggerUndo}
                             refetch={this.props.refetch}
+                            isPast={this.props.isPast}
                         />
                     ))
                 }

--- a/client/src/components/includes/SessionQuestionsContainer.tsx
+++ b/client/src/components/includes/SessionQuestionsContainer.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import SessionQuestion from './SessionQuestion';
 import { Icon } from 'semantic-ui-react';
+import * as moment from 'moment';
 
 class SessionQuestionsContainer extends React.Component {
     props: {
@@ -10,7 +11,9 @@ class SessionQuestionsContainer extends React.Component {
         handleJoinClick: Function,
         triggerUndo: Function,
         refetch: Function,
-        isOpen: boolean
+        isOpen: boolean,
+        isPast: boolean,
+        openingTime: Date,
     };
 
     render() {
@@ -55,10 +58,21 @@ class SessionQuestionsContainer extends React.Component {
                 {questions && questions.length === 0 &&
                     <React.Fragment>
                         <p className="noQuestionsHeading">
-                            {this.props.isOpen ? 'Queue Currently Empty' : 'Queue Not Open'}
+                            {this.props.isOpen ? 'Queue Currently Empty' :
+                                this.props.isPast ? 'Queue Has Closed' : 'Queue Not Open Yet'}
                         </p>
                         {!this.props.isOpen ?
-                            <p className="noQuestionsWarning">The queue hasn't opened yet or the session ended.</p> :
+                            (
+                                this.props.isPast ?
+                                    <p className="noQuestionsWarning">This office hour session has ended.</p> :
+                                    <p className="noQuestionsWarning">
+                                        Please check back at {moment(this.props.openingTime).format('h:mm A')}
+                                        {
+                                            moment().startOf('day') === moment(this.props.openingTime).startOf('day') ?
+                                                '' : (' on ' + moment(this.props.openingTime).format('D MMM'))
+                                        }!
+                                    </p>
+                            ) :
                             !this.props.isTA
                                 ? <p className="noQuestionsWarning">Be the first to join the queue!</p>
                                 : <p className="noQuestionsWarning">No questions in the queue yet. </p>

--- a/client/src/components/includes/SessionQuestionsContainer.tsx
+++ b/client/src/components/includes/SessionQuestionsContainer.tsx
@@ -14,6 +14,7 @@ class SessionQuestionsContainer extends React.Component {
         isOpen: boolean,
         isPast: boolean,
         openingTime: Date,
+        haveAnotherQuestion: boolean,
     };
 
     render() {
@@ -22,10 +23,23 @@ class SessionQuestionsContainer extends React.Component {
 
         return (
             <div className="SessionQuestionsContainer splitQuestions" >
-                {!this.props.isTA && myQuestion && myQuestion.length === 0 && this.props.isOpen &&
+                {!this.props.isTA && myQuestion && myQuestion.length === 0 && this.props.isOpen
+                    && !this.props.haveAnotherQuestion &&
                     <div className="SessionJoinButton" onClick={() => this.props.handleJoinClick()}>
                         <p><Icon name="plus" /> Join the Queue</p>
                     </div>
+                }
+                {!this.props.isTA && myQuestion && myQuestion.length === 0 && this.props.isOpen
+                    && this.props.haveAnotherQuestion &&
+                    <React.Fragment>
+                        <div className="SessionClosedMessage">
+                            You are holding a spot in another active queue.
+                            To join this queue instead, please retract your question from the other queue!
+                        </div>
+                        <div className="SessionJoinButton disabled">
+                            <p><Icon name="plus" /> Join the Queue</p>
+                        </div>
+                    </React.Fragment>
                 }
                 {questions && questions.length > 0 && this.props.isPast &&
                     <div className="SessionClosedMessage">

--- a/client/src/components/includes/SessionView.tsx
+++ b/client/src/components/includes/SessionView.tsx
@@ -162,9 +162,17 @@ class SessionView extends React.Component {
         });
     }
 
-    isOpen = (session: AppSession, interval: AppInterval) => {
+    isOpen = (session: AppSession, interval: AppInterval): boolean => {
         return new Date(session.startTime).getTime() - Interval.toMillisecoonds(interval) < new Date().getTime()
             && new Date(session.endTime) > new Date();
+    }
+
+    isPast = (session: AppSession): boolean => {
+        return new Date() > new Date(session.endTime);
+    }
+
+    getOpeningTime = (session: AppSession, interval: AppInterval): Date => {
+        return new Date(new Date(session.startTime).getTime() - Interval.toMillisecoonds(interval));
     }
 
     render() {
@@ -251,8 +259,12 @@ class SessionView extends React.Component {
                                             // this sets a ref, which allows a parent to call methods on a child.
                                             // Here, the parent can't access refetch, but the child can.
                                             ref={(ref) => this.questionsContainer = ref}
-                                            isOpen={this.isOpen(data.sessionBySessionId,
-                                                                data.courseByCourseId.queueOpenInterval)}
+                                            isOpen={this.isOpen(
+                                                data.sessionBySessionId,
+                                                data.courseByCourseId.queueOpenInterval)}
+                                            isPast={this.isPast(data.sessionBySessionId)}
+                                            openingTime={this.getOpeningTime(
+                                                data.sessionBySessionId, data.courseByCourseId.queueOpenInterval)}
                                         />
                                     </React.Fragment>
                                 }

--- a/client/src/components/pages/ProfessorDashboardView.tsx
+++ b/client/src/components/pages/ProfessorDashboardView.tsx
@@ -1,12 +1,9 @@
 import * as React from 'react';
-import ProfessorTagsTable from '../includes/ProfessorTagsTable';
-import ProfessorAddNew from '../includes/ProfessorAddNew';
 import TopBar from '../includes/TopBar';
 import ProfessorSidebar from '../includes/ProfessorSidebar';
 import gql from 'graphql-tag';
 import { Query } from 'react-apollo';
 import { Redirect } from 'react-router';
-import { Loader } from 'semantic-ui-react';
 
 const METADATA_QUERY = gql`
 query GetMetadata($courseId: Int!) {
@@ -26,32 +23,6 @@ query GetMetadata($courseId: Int!) {
     }
 }`;
 
-const TAGS_QUERY = gql`
-query FindTagsByCourse($courseId: Int!) {
-    courseByCourseId(courseId: $courseId) {
-        code
-        tagsByCourseId(condition:{level:1}) {
-            nodes {
-              	tagId
-                name
-                level
-                activated
-              	tagRelationsByParentId {
-                  nodes {
-                    tagByChildId {
-                      tagId
-                      name
-                      level
-                      activated
-                    }
-                  }
-                }
-            }
-        }
-    }
-}
-`;
-
 interface ProfessorMetadataData {
     apiGetCurrentUser: {
         nodes: [AppUserRole]
@@ -61,26 +32,14 @@ interface ProfessorMetadataData {
     };
 }
 
-interface ProfessorTagsData {
-    courseByCourseId: {
-        tagsByCourseId: {
-            nodes: [AppTag]
-        }
-    };
-}
-
 interface MetadataVariables {
     courseId: number;
 }
 
-interface TagsVariables {
-    courseId: number;
-}
-
-class ProfessorTagsDataQuery extends Query<ProfessorTagsData, TagsVariables> { }
 class ProfessorMetadataDataQuery extends Query<ProfessorMetadataData, MetadataVariables> { }
 
-class ProfessorView extends React.Component {
+class ProfessorDashboardView extends React.Component {
+
     props: {
         match: {
             params: {
@@ -115,7 +74,7 @@ class ProfessorView extends React.Component {
                                 <ProfessorSidebar
                                     courseId={this.props.match.params.courseId}
                                     code={courseCode}
-                                    selected={1}
+                                    selected={2}
                                 />
                                 {data && data.apiGetCurrentUser &&
                                     <TopBar
@@ -125,43 +84,20 @@ class ProfessorView extends React.Component {
                                         role={data.apiGetCurrentUser.nodes[0].courseUsersByUserId.nodes[0].role}
                                     />
                                 }
+                                <section className="rightOfSidebar">
+                                    <div className="main">
+                                        <p className="ComingSoon">
+                                            Coming soon!
+                                        </p>
+                                    </div>
+                                </section>
                             </React.Fragment>
                         );
                     }}
                 </ProfessorMetadataDataQuery>
-
-                <ProfessorTagsDataQuery
-                    query={TAGS_QUERY}
-                    variables={{
-                        courseId: this.props.match.params.courseId
-                    }}
-                >
-                    {({ loading, data, refetch }) => {
-                        return (
-                            <section className="rightOfSidebar">
-                                <div className="main">
-                                    <ProfessorAddNew
-                                        courseId={this.props.match.params.courseId}
-                                        refreshCallback={refetch}
-                                    />
-                                    {loading && <Loader active={true} content={'Loading...'} />}
-                                    {!loading && data && data.courseByCourseId.tagsByCourseId.nodes.length > 0 &&
-                                        <div className="Calendar">
-                                            <ProfessorTagsTable
-                                                tags={data.courseByCourseId.tagsByCourseId.nodes}
-                                                refreshCallback={refetch}
-                                                courseId={this.props.match.params.courseId}
-                                            />
-                                        </div>
-                                    }
-                                </div>
-                            </section>
-                        );
-                    }}
-                </ProfessorTagsDataQuery>
             </div>
         );
     }
 }
 
-export default ProfessorView;
+export default ProfessorDashboardView;

--- a/client/src/components/pages/ProfessorView.tsx
+++ b/client/src/components/pages/ProfessorView.tsx
@@ -167,7 +167,7 @@ class ProfessorView extends React.Component {
                                 <ProfessorSidebar
                                     courseId={this.props.match.params.courseId}
                                     code={courseCode}
-                                    selected={2}
+                                    selected={0}
                                 />
                                 {data && data.apiGetCurrentUser &&
                                     <TopBar

--- a/client/src/components/pages/ProfessorView.tsx
+++ b/client/src/components/pages/ProfessorView.tsx
@@ -10,6 +10,8 @@ import { DropdownItemProps } from 'semantic-ui-react';
 import 'moment-timezone';
 import { Redirect } from 'react-router';
 
+const ONE_DAY = 24 /* hours */ * 60 /* minutes */ * 60 /* seconds */ * 1000 /* millis */;
+
 const METADATA_QUERY = gql`
 query GetMetadata($courseId: Int!) {
     apiGetCurrentUser {
@@ -122,7 +124,8 @@ class ProfessorView extends React.Component {
         super(props);
         var week = new Date();
         week.setHours(0, 0, 0, 0);
-        week.setDate(week.getDate() + 1 - week.getDay());
+        var daysSinceMonday = ((week.getDay() - 1) + 7) % 7;
+        week.setTime(week.getTime() - daysSinceMonday * ONE_DAY); // beginning of this week's Monday
         var today = new Date();
         today.setHours(0, 0, 0, 0);
         this.state = {
@@ -218,6 +221,7 @@ class ProfessorView extends React.Component {
                                     />
                                     <CalendarWeekSelect
                                         handleClick={this.handleWeekClick}
+                                        selectedWeekEpoch={this.state.selectedWeekEpoch}
                                     />
 
                                     <div className="Calendar">

--- a/client/src/components/types/appData.d.ts
+++ b/client/src/components/types/appData.d.ts
@@ -87,3 +87,11 @@ interface AppUserRole extends AppUser {
         }]
     }
 }
+
+interface AppUserRoleQuestions extends AppUserRole {
+    questionsByAskerId: {
+        nodes: [{
+            sessionBySessionId: AppSession
+        }]
+    }
+}

--- a/client/src/styles/TopBar.less
+++ b/client/src/styles/TopBar.less
@@ -25,8 +25,8 @@
 .topBar {
     background-color: white;
     width: 100%;
-    height: 60px;
-    padding-right: 60px;
+    height: 46px;
+    padding-right: 46px;
     box-shadow: 0 1px 6px 1px rgba(208, 208, 208, 0.47);
     user-select: none;
 
@@ -41,8 +41,8 @@
     }
 
     img {
-        width: 30px;
-        height: 30px;
+        width: 28px;
+        height: 28px;
         border-radius: 50%;
         margin: 0px 12px 0px 30px;
     }

--- a/client/src/styles/calendar/CalendarDaySelect.less
+++ b/client/src/styles/calendar/CalendarDaySelect.less
@@ -19,6 +19,10 @@
         justify-content: space-between;
         align-items: center;
         padding: 15px;
+
+        .LastWeek, .NextWeek {
+            cursor: pointer;
+        }
     }
  }
 

--- a/client/src/styles/calendar/CalendarHeader.less
+++ b/client/src/styles/calendar/CalendarHeader.less
@@ -24,6 +24,10 @@
             display: inline-block;
             padding-top: 0;
             margin-left: 5px;
+
+            &.Professor {
+                width: 40px;
+            }
         }
     }
 
@@ -38,9 +42,10 @@
 
     @media only screen and (max-width: @mobile-breakpoint) {
         .mobileHeaderFace {
-            height: 28px;
+            height: 24px;
             border-radius: 28px;
             display: inline;
+            cursor: pointer;
         }
     }
 }

--- a/client/src/styles/professor/ProfessorTagInfo.less
+++ b/client/src/styles/professor/ProfessorTagInfo.less
@@ -55,6 +55,7 @@
             font-size: 12px;
             margin-right: 30px;
             position: relative;
+            padding-right: 10px;
 
             .Remove {
                 position: absolute;

--- a/client/src/styles/professor/ProfessorView.less
+++ b/client/src/styles/professor/ProfessorView.less
@@ -10,6 +10,14 @@
             background-color: transparent;
             border-top: none;
         }
+
+        .ComingSoon {
+            padding-top: 200px;
+            font-family: Roboto;
+            font-size: 28px;
+            font-weight: 300;
+            color: #474747;
+        }
     }
 
     input {

--- a/client/src/styles/session/AddQuestion.less
+++ b/client/src/styles/session/AddQuestion.less
@@ -91,6 +91,14 @@
 
         .header {
             font-size: 15px;
+            
+            .characterCount {
+              color: #717171;
+              
+              &.warn {
+                color: #ce2a2a;
+              }
+            }
         }
 
         .placeHolder {

--- a/client/src/styles/session/SessionInformationHeader.less
+++ b/client/src/styles/session/SessionInformationHeader.less
@@ -76,19 +76,23 @@
 
     .header {
         padding: 10px 25px 10px 20px;
+        text-align:left;
 
         .BackButton {
-            font-size: 17px;
-            font-weight: bold;
+            font-size: 15px;
+            font-weight: 500;
             text-align: left;
             margin: 0px;
-            color: #4d4d4d;
+            color: #484848;
+            cursor: pointer;
+            display: inline-block;
 
             .left {
-                border: solid #4d4d4d;
+                border: solid #484848;
                 border-width: 0 1px 1px 0;
                 display: inline-block;
-                padding: 5px;
+                padding: 4px;
+                margin-right: 10px;
             }
 
             .left {
@@ -118,11 +122,10 @@
 
             .Picture {
                 float: right;
-                padding-right: 30px;
+                padding-right: 10px;
 
                 img {
                     display: inline-block;
-                    margin-right: 10px;
                     width: 60px;
                     height: 60px;
                     border-radius: 35px;

--- a/client/src/styles/session/SessionJoinButton.less
+++ b/client/src/styles/session/SessionJoinButton.less
@@ -8,6 +8,14 @@
     border-radius: 3px;
     box-shadow: 0px 2px 3px #aaaaaa;
     user-select: none;
+    cursor: pointer;
+
+    &.disabled {
+        background: #d2d2d2;
+        border: none;
+        box-shadow: none;
+        cursor: default;
+    }
 
     p {
         margin: auto;
@@ -15,6 +23,5 @@
         color: white;
         font-size: 15px;
         vertical-align: middle;
-        cursor: pointer;
     }
 }

--- a/client/src/styles/session/SessionQuestionsContainer.less
+++ b/client/src/styles/session/SessionQuestionsContainer.less
@@ -30,8 +30,8 @@
     .SessionClosedMessage {
         margin: 20px auto;
         padding: 0 10px;
-        font-size: 20px;
-        font-weight: 500;
+        font-size: 19px;
+        font-weight: 400;
         letter-spacing: 0.3px;
         color: #474747;
     }

--- a/client/src/styles/session/SessionQuestionsContainer.less
+++ b/client/src/styles/session/SessionQuestionsContainer.less
@@ -26,6 +26,15 @@
         font-size: 19.2px;
         color: #474747;
     }
+
+    .SessionClosedMessage {
+        margin: 20px auto;
+        padding: 0 10px;
+        font-size: 20px;
+        font-weight: 500;
+        letter-spacing: 0.3px;
+        color: #474747;
+    }
 }
 
 
@@ -41,6 +50,11 @@
 
         .Queue, .QuestionHeader {
             margin-left:12px;
+        }
+
+        .SessionClosedMessage {
+            margin: 20px auto;
+            font-size: 16px;
         }
     }
 }

--- a/server/database/migrations/0003_fix_tags_policy.sql
+++ b/server/database/migrations/0003_fix_tags_policy.sql
@@ -1,0 +1,8 @@
+DROP POLICY insert_policy ON public.question_tags;
+CREATE POLICY insert_policy ON public.question_tags FOR INSERT TO backend WITH CHECK (( SELECT public.internal_owns_question(question_id) AS internal_owns_question));
+
+DROP POLICY update_policy ON public.question_tags;
+CREATE POLICY update_policy ON public.question_tags FOR UPDATE TO backend USING (( SELECT public.internal_owns_question(question_id) AS internal_owns_question));
+
+DROP POLICY delete_policy ON public.question_tags;
+CREATE POLICY delete_policy ON public.question_tags FOR DELETE TO backend USING (( SELECT public.internal_owns_question(question_id) AS internal_owns_question));

--- a/server/database/mock_database.sql
+++ b/server/database/mock_database.sql
@@ -1922,9 +1922,7 @@ CREATE POLICY delete_policy ON public.tag_relations FOR DELETE TO backend USING 
 -- Name: question_tags delete_policy; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY delete_policy ON public.question_tags FOR DELETE TO backend USING ((( SELECT questions.asker_id
-   FROM public.questions
-  WHERE (questions.question_id = questions.question_id)) = ( SELECT public.internal_get_user_id() AS internal_get_user_id)));
+CREATE POLICY delete_policy ON public.question_tags FOR DELETE TO backend USING (( SELECT public.internal_owns_question(question_tags.question_id) AS internal_owns_question));
 
 
 --
@@ -1984,19 +1982,17 @@ CREATE POLICY insert_policy ON public.tag_relations FOR INSERT TO backend WITH C
 
 
 --
--- Name: question_tags insert_policy; Type: POLICY; Schema: public; Owner: -
---
-
-CREATE POLICY insert_policy ON public.question_tags FOR INSERT TO backend WITH CHECK ((( SELECT questions.asker_id
-   FROM public.questions
-  WHERE (questions.question_id = questions.question_id)) = ( SELECT public.internal_get_user_id() AS internal_get_user_id)));
-
-
---
 -- Name: questions insert_policy; Type: POLICY; Schema: public; Owner: -
 --
 
 CREATE POLICY insert_policy ON public.questions FOR INSERT TO backend WITH CHECK (((asker_id = ( SELECT public.internal_get_user_id() AS internal_get_user_id)) AND ( SELECT public.internal_is_queue_open(questions.session_id) AS internal_is_queue_open)));
+
+
+--
+-- Name: question_tags insert_policy; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY insert_policy ON public.question_tags FOR INSERT TO backend WITH CHECK (( SELECT public.internal_owns_question(question_tags.question_id) AS internal_owns_question));
 
 
 --
@@ -2181,19 +2177,17 @@ CREATE POLICY update_policy ON public.tag_relations FOR UPDATE TO backend USING 
 
 
 --
--- Name: question_tags update_policy; Type: POLICY; Schema: public; Owner: -
---
-
-CREATE POLICY update_policy ON public.question_tags FOR UPDATE TO backend USING ((( SELECT questions.asker_id
-   FROM public.questions
-  WHERE (questions.question_id = questions.question_id)) = ( SELECT public.internal_get_user_id() AS internal_get_user_id)));
-
-
---
 -- Name: questions update_policy; Type: POLICY; Schema: public; Owner: -
 --
 
 CREATE POLICY update_policy ON public.questions FOR UPDATE TO backend USING (( SELECT public.internal_owns_question(questions.question_id) AS internal_owns_question));
+
+
+--
+-- Name: question_tags update_policy; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY update_policy ON public.question_tags FOR UPDATE TO backend USING (( SELECT public.internal_owns_question(question_tags.question_id) AS internal_owns_question));
 
 
 --


### PR DESCRIPTION
- Fixed bugs with the calendar date picker
- Added character limit front-end (no design, need to revisit)
- Added placeholder dashboard view with a coming soon message
- Fixed tags policy bug with Migration 0003
- Split closed queue state into 'past' and 'future' for more descriptive messages
- Show message for past queues where there are unresolved questions
- Hide 'retract' action from past queues
- Minor CSS fixes
- Front-end that enforces '1 question per user per course' limit
- Allow only one secondary tag for 3110
- Fixed Professor Tags bugs
- Demo-ready