### PR TITLE
Fixing up 0002 for production

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -265,9 +265,9 @@ Junction table (many-to-many relationship) between [questions](#questions) and [
 |Operation|Who is allowed?|
 |:---:|---|
 |Read|All users|
-|Insert|User who asked the question|
-|Update|User who asked the question|
-|Delete|User who asked the question|
+|Insert|Logged-in student; TAs and professors for the course|
+|Update|User who asked the question; TAs and professors for the course|
+|Delete|User who asked the question; TAs and professors for the course|
 
 ## Functions
 

--- a/server/database/migrations/0002_fix_aws_roles.sql
+++ b/server/database/migrations/0002_fix_aws_roles.sql
@@ -1,1 +1,2 @@
 GRANT backend TO postgres;
+GRANT backend TO ohprod1;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

### Description
<!-- Describe your changes -->
Fixes a small bug in migration 0002 that made it fail in production. In short, the username in production is `ohprod1`, whereas it is `postgres` on staging (and usually on local as well).

### Inside This PR
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->
* Updated migration 0002 and applied it to production -- staging and local remain unchanged
* Updated database docs with some authorization details that were not documented in a previous PR

### Notes <!-- Optional -->
<!--- List any important or subtle points, future considerations, or other items of note. -->
As far as this particular SQL statement goes (`GRANT backend TO...`), note that it doesn't need to be part of `mock_database.sql`. This is because roles are managed outside of a particular database schema; roles exist at the database level. Essentially, roles are a one-time setup, and you can change the schema independently of them. While setting up a database locally for the first time, a developer on the team will need to run `GRANT backend TO <username>` for whatever their Postgres username is, since this isn't captured in `mock_database.sql`.

### Breaking Changes
<!-- Put an `x` in all the boxes that apply: -->
- [x] Database schema change (anything that changes Postgres)
(But only affects production, so no need to pull any changes locally)
- [ ] I updated existing types in `/src/components/types/`

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My changes requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
- [x] I tested affected functionality
- [ ] I resolved any merge conflicts
- [x] My PR is ready for review
