### PR TITLE
Unselect a TA

### DIFF
--- a/client/src/components/includes/ProfessorOHInfo.tsx
+++ b/client/src/components/includes/ProfessorOHInfo.tsx
@@ -219,7 +219,7 @@ class ProfessorOHInfo extends React.Component {
     }
 
     handleTaList(event: React.SyntheticEvent<HTMLElement>, data: DropdownProps, index: number) {
-        this.state.taSelected[index] = Number(data.value);
+        this.state.taSelected[index] = Number(data.value) || undefined;
         this.setState({ taSelected: this.state.taSelected });
         this.updateNotification('');
     }
@@ -231,7 +231,8 @@ class ProfessorOHInfo extends React.Component {
             taSelected: [undefined],
             locationBuildingSelected: '',
             locationRoomNumSelected: '',
-            isSeriesMutation: false
+            isSeriesMutation: this.props.sessionSeriesId !== null,
+            title: ''
         });
     }
 
@@ -269,7 +270,8 @@ class ProfessorOHInfo extends React.Component {
 
     render() {
         var isMaxTA = false;
-        if (this.state.taSelected.length >= this.props.taOptions.length) {
+        // -1 to account for the "TA Name" placeholder
+        if (this.state.taSelected.length >= this.props.taOptions.length - 1) {
             isMaxTA = true;
         }
 

--- a/client/src/components/pages/ProfessorView.tsx
+++ b/client/src/components/pages/ProfessorView.tsx
@@ -197,7 +197,7 @@ class ProfessorView extends React.Component {
                     fetchPolicy="network-only" // change this to no-cache when it is fixed in Apollo
                 >
                     {({ loading, data, refetch }) => {
-                        var taOptions: DropdownItemProps[] = [];
+                        var taOptions: DropdownItemProps[] = [{ text: 'TA Name' }];
                         if (!loading && data) {
                             data.courseByCourseId.tas.nodes.forEach((node) => {
                                 taOptions.push({


### PR DESCRIPTION
### Description
<!-- Describe your changes -->
Gives the ability to assign no TAs to an office hour

### Inside This PR
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->
* Adds an option to deselect a TA from the dropdown

### Notes <!-- Optional -->
<!--- List any important or subtle points, future considerations, or other items of note. -->
When saving changes of an existing session/series, the old info remains in the editor, including any unselected TA fields. In general, it might be best to requery all of the info for a particular session when saving changes and canceling edits so that any changes are reset.

### Breaking Changes
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Database schema change (anything that changes Postgres)
- [ ] I updated existing types in `/src/components/types/`

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My changes requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
- [x] I tested affected functionality
- [ ] I resolved any merge conflicts
- [x] My PR is ready for review
