### PR TITLE
Fixed session creation bug

### DIFF
--- a/server/database/migrations/0005_session_sunday_bug.sql
+++ b/server/database/migrations/0005_session_sunday_bug.sql
@@ -1,0 +1,46 @@
+DROP FUNCTION public.internal_create_sessions_from_series;
+
+CREATE FUNCTION public.internal_create_sessions_from_series(_series_id integer) RETURNS SETOF public.sessions
+    LANGUAGE plpgsql
+    AS $$
+declare
+course integer;
+building text;
+room text;
+start_date_week timestamp with time zone;
+start_date timestamp with time zone;
+end_date_week timestamp with time zone;
+end_date timestamp with time zone;
+cur_date timestamp with time zone;
+session_start_time timestamp with time zone;
+session_end_time timestamp with time zone;
+session_start_offset interval;
+session_end_offset interval;
+title text;
+begin
+IF (SELECT COUNT(*) FROM sessions where session_series_id = _series_id) > 0 THEN
+    RAISE EXCEPTION 'Sessions with this series_id already exist!';
+END IF;
+course := (SELECT course_id FROM session_series WHERE session_series_id = _series_id);
+start_date_week := date_trunc('week', (SELECT courses.start_date from courses WHERE course_id = course));
+start_date := date_trunc('day', (SELECT courses.start_date from courses WHERE course_id = course));
+end_date_week := date_trunc('week', (SELECT courses.end_date from courses WHERE course_id = course));
+end_date := date_trunc('day', (SELECT courses.end_date from courses WHERE course_id = course));
+SELECT session_series.start_time, session_series.end_time, session_series.building, session_series.room, session_series.title
+    INTO session_start_time, session_end_time, building, room, title
+    FROM session_series WHERE session_series_id = _series_id;
+session_start_offset := session_start_time - date_trunc('week', session_start_time);
+session_end_offset := session_end_time - date_trunc('week', session_start_time) ;
+cur_date := start_date_week;
+while cur_date <= end_date_week loop
+	if ((cur_date + session_end_offset) > NOW()) and ((cur_date + session_start_offset) >= start_date)
+		and ((cur_date + session_start_offset) <= (end_date + interval '1 day')) then
+		INSERT INTO sessions(start_time, end_time, building, room, session_series_id, course_id, title)
+		values
+		(cur_date + session_start_offset, cur_date + session_end_offset, building, room, _series_id, course, title);
+    end if;
+	cur_date := cur_date + interval '1 week';
+END LOOP;
+RETURN QUERY (SELECT * FROM sessions where session_series_id = _series_id);
+END
+$$;


### PR DESCRIPTION
Fixing a session creation backend bug with a database migration.

### Description
There was a bug (caught in production earlier today) where sessions created as part of a series had their end times exactly one week before they should have (for eg, a session would start Sunday 9/9 and end Sunday 9/2). This was down to a bug in the session creation code (in the database layer), which this change fixes through a migration.

### Inside This PR
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->
* Added migration 0005: while creating session instances from a series, we were computing start and end 'offsets', which are meant to represent the amount of time between the start of the week, and the start/end times of the session series. This is then used to iterate over following weeks and create sessions at the right times. The end time offset was being computed as (end time - week start of end time), which resulted in late Sunday sessions' end times overflowing to the following week, which gave them an offset 7 days lesser than intended. The fix is to instead compute end time offset as (end time - week start of _start_ time), which ensures that both offsets are computed relative to the same week start.
* Applied migrations 0004 and 0005 to `mock_database.sql`, updated with some new mock data (including sessions with 0 TAs and a name)

### Notes <!-- Optional -->
The current Sunday sessions in production will need to be updated manually.

### Breaking Changes
<!-- Put an `x` in all the boxes that apply: -->
- [x] Database schema change (anything that changes Postgres)
- [ ] I updated existing types in `/src/components/types/`

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My changes requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
- [x] I tested affected functionality
- [ ] I resolved any merge conflicts
- [x] My PR is ready for review
