### PR TITLE
"Your question is up!" Notification Fix

### DIFF
--- a/client/src/components/includes/SessionQuestionsContainer.tsx
+++ b/client/src/components/includes/SessionQuestionsContainer.tsx
@@ -43,12 +43,19 @@ class SessionQuestionsContainer extends React.Component {
 
     render() {
         var questions = this.props.questions;
+
         // If the user has questions, store them in myQuestion[]
         var myQuestion = questions && questions.filter(q => q.userByAskerId.userId === this.props.myUserId);
         // Make sure that the data has loaded and user has a question
         if (questions && myQuestion && myQuestion.length > 0) {
             // Get user's position in queue (0 indexed)
             let myQuestionIndex = questions.indexOf(myQuestion[0]);
+            // Check how many questions ahead of the user are in progress
+            let numProgressQuestions = questions.slice(0, myQuestionIndex).reduce(
+                (isProgress, question) => isProgress + (question.status === 'assigned' ? 1 : 0), 0
+            );
+            // Calculate question index by subtracting number of progress questions
+            myQuestionIndex -= numProgressQuestions;
             // Update tab with user position
             document.title = '(' + (1 + myQuestionIndex) + ') Queue Me In';
             // if user is up and we haven't already sent a notification, send one.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
Fixes the issue where the notification only shows if the user's question is the absolute first question in the queue, even if the questions ahead are all in progress.

### Inside This PR
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->
* Subtracts number of questions in progress from the user's position to reflect the position more accurately

### Notes <!-- Optional -->
<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Database schema change (anything that changes Postgres)
- [ ] I updated existing types in `/src/components/types/`
- [ ] Other change that could cause problems (Detailed in notes)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My changes requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
- [x] I tested affected functionality
- [ ] I resolved any merge conflicts
- [x] My PR is ready for review
