### PR TITLE
Default courseId uses localStorage then 5 as fallback

### DIFF
--- a/client/src/components/App.tsx
+++ b/client/src/components/App.tsx
@@ -17,7 +17,7 @@ import { Loader } from 'semantic-ui-react';
 
 ReactGA.initialize('UA-123790900-1');
 
-const DEFAULT_COURSE_ID = 5;
+const DEFAULT_COURSE_ID = String(window.localStorage.getItem('lastid') || 5);
 
 const GET_USER_AND_COURSE = gql`
 query GetUserAndCourse($courseId: Int!) {
@@ -112,7 +112,7 @@ class App extends React.Component {
                         <PrivateRoute path="/course/:courseId" component={SplitView} />
                         <Redirect
                             from="/"
-                            to={'/course/' + (String(window.localStorage.getItem('lastid') || DEFAULT_COURSE_ID))}
+                            to={'/course/' + DEFAULT_COURSE_ID}
                         />
                     </Switch>
                 </div>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

### Inside This PR
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->
* Rather than just defaulting to 5, first try redirecting users to the saved course in localStorage, if that doesn't exist then redirect them to courseId 5.

### Notes <!-- Optional -->
<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Database schema change (anything that changes Postgres)
- [ ] I updated existing types in `/src/components/types/`
- [ ] Other change that could cause problems (Detailed in notes)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My changes requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
- [x] I tested affected functionality
- [x] I resolved any merge conflicts
- [x] My PR is ready for review
