### PR TITLE
Leave Other Queues

### DIFF
--- a/client/src/components/includes/SessionQuestionsContainer.tsx
+++ b/client/src/components/includes/SessionQuestionsContainer.tsx
@@ -102,105 +102,101 @@ class SessionQuestionsContainer extends React.Component {
         // console.log('questions associated w/ this session', questions);
 
         return (
-            <div className="SessionQuestionsContainer splitQuestions" >
-                {!this.props.isTA && myQuestion && myQuestion.length === 0 && this.props.isOpen
-                    && !this.props.haveAnotherQuestion &&
-                    <div className="SessionJoinButton" onClick={() => this.props.handleJoinClick()}>
-                        <p><Icon name="plus" /> Join the Queue</p>
-                    </div>
-                }
+            <React.Fragment>
                 {!this.props.isTA && myQuestion && myQuestion.length === 0 && this.props.isOpen
                     && this.props.haveAnotherQuestion &&
                     <React.Fragment>
-                        <div className="SessionClosedMessage">
-                            You are holding a spot in another active queue.
-
+                        <div className="SessionLeaveQueueMessage">
                             <Mutation mutation={LEAVE_QUEUE} onCompleted={this.dismissLeaveQueue}>
                                 {(leaveQueue) =>
-                                    <div className="leaveQueueContainer">
-                                        <p className="leaveQueueText">
-                                            <span
-                                                className="leaveQueue"
-                                                onClick={() =>
-                                                    this.handleLeaveQueue(leaveQueue, this.props.refetch)
-                                                }
-                                            >
-                                                To join this queue, retract your question <b>here.</b>
-                                            </span>
-                                        </p>
-                                    </div>
+                                    <span
+                                        className="leaveQueue"
+                                        onClick={() =>
+                                            this.handleLeaveQueue(leaveQueue, this.props.refetch)
+                                        }
+                                    >
+                                        You have already joined a queue! <span className="removeQuestionLeaveQueue">
+                                            Remove your question to join another queue.
+                                        </span>
+                                    </span>
                                 }
                             </Mutation>
                         </div>
-                        <div className="SessionJoinButton disabled">
+                    </React.Fragment>
+                }
+                <div className="SessionQuestionsContainer splitQuestions" >
+                    {!this.props.isTA && myQuestion && myQuestion.length === 0 && this.props.isOpen
+                        && !this.props.haveAnotherQuestion &&
+                        <div className="SessionJoinButton" onClick={() => this.props.handleJoinClick()}>
                             <p><Icon name="plus" /> Join the Queue</p>
                         </div>
-                    </React.Fragment>
-                }
-                {questions && questions.length > 0 && this.props.isPast &&
-                    <div className="SessionClosedMessage">
-                        This queue has closed and is no longer accepting new questions.
+                    }
+                    {questions && questions.length > 0 && this.props.isPast &&
+                        <div className="SessionClosedMessage">
+                            This queue has closed and is no longer accepting new questions.
                     </div>
-                }
-                {questions && myQuestion && myQuestion.length > 0 &&
-                    <div className="User">
-                        <p className="QuestionHeader">My Question</p>
-                        <SessionQuestion
-                            key={myQuestion[0].questionId}
-                            question={myQuestion[0]}
-                            index={questions.indexOf(myQuestion[0])}
-                            isTA={this.props.isTA}
-                            includeRemove={true}
-                            includeBookmark={false}
-                            triggerUndo={this.props.triggerUndo}
-                            refetch={this.props.refetch}
-                            isPast={this.props.isPast}
-                            myUserId={this.props.myUserId}
-                        />
-                        <p className="Queue">Queue</p>
-                    </div>
-                }
-                {questions && questions.length > 0 &&
-                    questions.map((question, i: number) => (
-                        <SessionQuestion
-                            key={question.questionId}
-                            question={question}
-                            index={i}
-                            isTA={this.props.isTA}
-                            includeRemove={false}
-                            includeBookmark={question.userByAskerId.userId === this.props.myUserId}
-                            triggerUndo={this.props.triggerUndo}
-                            refetch={this.props.refetch}
-                            isPast={this.props.isPast}
-                            myUserId={this.props.myUserId}
-                        />
-                    ))
-                }
-                {questions && questions.length === 0 &&
-                    <React.Fragment>
-                        <p className="noQuestionsHeading">
-                            {this.props.isOpen ? 'Queue Currently Empty' :
-                                this.props.isPast ? 'Queue Has Closed' : 'Queue Not Open Yet'}
-                        </p>
-                        {!this.props.isOpen ?
-                            (
-                                this.props.isPast ?
-                                    <p className="noQuestionsWarning">This office hour session has ended.</p> :
-                                    <p className="noQuestionsWarning">
-                                        Please check back at {moment(this.props.openingTime).format('h:mm A')}
-                                        {
-                                            moment().startOf('day') === moment(this.props.openingTime).startOf('day') ?
-                                                '' : (' on ' + moment(this.props.openingTime).format('MMM D'))
-                                        }!
+                    }
+                    {questions && myQuestion && myQuestion.length > 0 &&
+                        <div className="User">
+                            <p className="QuestionHeader">My Question</p>
+                            <SessionQuestion
+                                key={myQuestion[0].questionId}
+                                question={myQuestion[0]}
+                                index={questions.indexOf(myQuestion[0])}
+                                isTA={this.props.isTA}
+                                includeRemove={true}
+                                includeBookmark={false}
+                                triggerUndo={this.props.triggerUndo}
+                                refetch={this.props.refetch}
+                                isPast={this.props.isPast}
+                                myUserId={this.props.myUserId}
+                            />
+                            <p className="Queue">Queue</p>
+                        </div>
+                    }
+                    {questions && questions.length > 0 &&
+                        questions.map((question, i: number) => (
+                            <SessionQuestion
+                                key={question.questionId}
+                                question={question}
+                                index={i}
+                                isTA={this.props.isTA}
+                                includeRemove={false}
+                                includeBookmark={question.userByAskerId.userId === this.props.myUserId}
+                                triggerUndo={this.props.triggerUndo}
+                                refetch={this.props.refetch}
+                                isPast={this.props.isPast}
+                                myUserId={this.props.myUserId}
+                            />
+                        ))
+                    }
+                    {questions && questions.length === 0 &&
+                        <React.Fragment>
+                            <p className="noQuestionsHeading">
+                                {this.props.isOpen ? 'Queue Currently Empty' :
+                                    this.props.isPast ? 'Queue Has Closed' : 'Queue Not Open Yet'}
+                            </p>
+                            {!this.props.isOpen ?
+                                (
+                                    this.props.isPast ?
+                                        <p className="noQuestionsWarning">This office hour session has ended.</p> :
+                                        <p className="noQuestionsWarning">
+                                            Please check back at {moment(this.props.openingTime).format('h:mm A')}
+                                            {
+                                                moment().startOf('day') ===
+                                                    moment(this.props.openingTime).startOf('day')
+                                                    ? '' : (' on ' + moment(this.props.openingTime).format('MMM D'))
+                                            }!
                                     </p>
-                            ) :
-                            !this.props.isTA
-                                ? <p className="noQuestionsWarning">Be the first to join the queue!</p>
-                                : <p className="noQuestionsWarning">No questions in the queue yet. </p>
-                        }
-                    </React.Fragment>
-                }
-            </div>
+                                ) :
+                                !this.props.isTA
+                                    ? <p className="noQuestionsWarning">Be the first to join the queue!</p>
+                                    : <p className="noQuestionsWarning">No questions in the queue yet. </p>
+                            }
+                        </React.Fragment>
+                    }
+                </div>
+            </React.Fragment>
         );
     }
 }

--- a/client/src/components/includes/SessionQuestionsContainer.tsx
+++ b/client/src/components/includes/SessionQuestionsContainer.tsx
@@ -99,8 +99,6 @@ class SessionQuestionsContainer extends React.Component {
             }
         }
 
-        // console.log('questions associated w/ this session', questions);
-
         return (
             <React.Fragment>
                 {!this.props.isTA && myQuestion && myQuestion.length === 0 && this.props.isOpen

--- a/client/src/components/includes/SessionQuestionsContainer.tsx
+++ b/client/src/components/includes/SessionQuestionsContainer.tsx
@@ -7,7 +7,7 @@ import gql from 'graphql-tag';
 import { Mutation } from 'react-apollo';
 
 const LEAVE_QUEUE = gql`
-mutation UndoQuestion($questionId: Int!, $status: String!) {
+mutation LeaveQueue($questionId: Int!, $status: String!) {
     updateQuestionByQuestionId(input: {questionPatch: {status: $status, timeAddressed: null, answererId: null},
         questionId: $questionId}) {
         clientMutationId
@@ -114,7 +114,6 @@ class SessionQuestionsContainer extends React.Component {
                     <React.Fragment>
                         <div className="SessionClosedMessage">
                             You are holding a spot in another active queue.
-                            To join this queue, please
 
                             <Mutation mutation={LEAVE_QUEUE} onCompleted={this.dismissLeaveQueue}>
                                 {(leaveQueue) =>
@@ -126,7 +125,7 @@ class SessionQuestionsContainer extends React.Component {
                                                     this.handleLeaveQueue(leaveQueue, this.props.refetch)
                                                 }
                                             >
-                                                retract your question from the other queue!
+                                                To join this queue, retract your question <b>here.</b>
                                             </span>
                                         </p>
                                     </div>

--- a/client/src/components/includes/SessionQuestionsContainer.tsx
+++ b/client/src/components/includes/SessionQuestionsContainer.tsx
@@ -3,6 +3,17 @@ import SessionQuestion from './SessionQuestion';
 import { Icon } from 'semantic-ui-react';
 import * as moment from 'moment';
 
+// import gql from 'graphql-tag';
+// import { Query } from 'react-apollo';
+
+// const LEAVE_QUEUE = gql`
+// mutation UndoQuestion($questionId: Int!, $status: String!) {
+//     updateQuestionByQuestionId(input: {questionPatch: {status: $status, timeAddressed: null, answererId: null},
+//         questionId: $questionId}) {
+//         clientMutationId
+//     }
+// }
+// `;
 class SessionQuestionsContainer extends React.Component {
     props: {
         isTA: boolean,
@@ -15,6 +26,7 @@ class SessionQuestionsContainer extends React.Component {
         isPast: boolean,
         openingTime: Date,
         haveAnotherQuestion: boolean,
+        // add other info passed in as props
     };
 
     state: {
@@ -33,6 +45,15 @@ class SessionQuestionsContainer extends React.Component {
             // Do nothing. iOS crashes because Notification isn't defined
         }
     }
+
+    // handleLeaveQueue = (leaveQueue: Function, refetch: Function) => {
+    //     leaveQueue({
+    //         variables: {
+    //             questionId: null,
+    //             status: 'retracted'
+    //         }
+    //     });
+    // }
 
     constructor(props: {}) {
         super(props);
@@ -74,6 +95,8 @@ class SessionQuestionsContainer extends React.Component {
             }
         }
 
+        // console.log('questions associated w/ this session', questions);
+
         return (
             <div className="SessionQuestionsContainer splitQuestions" >
                 {!this.props.isTA && myQuestion && myQuestion.length === 0 && this.props.isOpen
@@ -88,6 +111,24 @@ class SessionQuestionsContainer extends React.Component {
                         <div className="SessionClosedMessage">
                             You are holding a spot in another active queue.
                             To join this queue, please retract your question from the other queue!
+
+                            {/* <Mutation mutation={LEAVE_QUEUE} onCompleted={this.dismissUndo}>
+                                {(leaveQueue) =>
+                                    <div className="leaveQueueContainer">
+                                        <p className="leaveQueueText">
+                                            {leaveQueueText}
+                                            <span
+                                                className="leaveQueue"
+                                                onClick={() =>
+                                                    this.handleLeaveQueue(leaveQueue, refetch)
+                                                }
+                                            >
+                                            Leave Other Queue
+                                            </span>
+                                        </p>
+                                    </div>
+                                }
+                            </Mutation> */}
                         </div>
                         <div className="SessionJoinButton disabled">
                             <p><Icon name="plus" /> Join the Queue</p>

--- a/client/src/components/includes/SessionQuestionsContainer.tsx
+++ b/client/src/components/includes/SessionQuestionsContainer.tsx
@@ -3,17 +3,17 @@ import SessionQuestion from './SessionQuestion';
 import { Icon } from 'semantic-ui-react';
 import * as moment from 'moment';
 
-// import gql from 'graphql-tag';
-// import { Query } from 'react-apollo';
+import gql from 'graphql-tag';
+import { Mutation } from 'react-apollo';
 
-// const LEAVE_QUEUE = gql`
-// mutation UndoQuestion($questionId: Int!, $status: String!) {
-//     updateQuestionByQuestionId(input: {questionPatch: {status: $status, timeAddressed: null, answererId: null},
-//         questionId: $questionId}) {
-//         clientMutationId
-//     }
-// }
-// `;
+const LEAVE_QUEUE = gql`
+mutation UndoQuestion($questionId: Int!, $status: String!) {
+    updateQuestionByQuestionId(input: {questionPatch: {status: $status, timeAddressed: null, answererId: null},
+        questionId: $questionId}) {
+        clientMutationId
+    }
+}
+`;
 class SessionQuestionsContainer extends React.Component {
     props: {
         isTA: boolean,
@@ -26,7 +26,7 @@ class SessionQuestionsContainer extends React.Component {
         isPast: boolean,
         openingTime: Date,
         haveAnotherQuestion: boolean,
-        // add other info passed in as props
+        otherQuestionsId: number[],
     };
 
     state: {
@@ -46,14 +46,18 @@ class SessionQuestionsContainer extends React.Component {
         }
     }
 
-    // handleLeaveQueue = (leaveQueue: Function, refetch: Function) => {
-    //     leaveQueue({
-    //         variables: {
-    //             questionId: null,
-    //             status: 'retracted'
-    //         }
-    //     });
-    // }
+    dismissLeaveQueue = () => {
+        this.props.refetch();
+    }
+
+    handleLeaveQueue = (leaveQueue: Function, refetch: Function) => {
+        leaveQueue({
+            variables: {
+                questionId: this.props.otherQuestionsId[0],
+                status: 'retracted'
+            }
+        });
+    }
 
     constructor(props: {}) {
         super(props);
@@ -110,25 +114,24 @@ class SessionQuestionsContainer extends React.Component {
                     <React.Fragment>
                         <div className="SessionClosedMessage">
                             You are holding a spot in another active queue.
-                            To join this queue, please retract your question from the other queue!
+                            To join this queue, please
 
-                            {/* <Mutation mutation={LEAVE_QUEUE} onCompleted={this.dismissUndo}>
+                            <Mutation mutation={LEAVE_QUEUE} onCompleted={this.dismissLeaveQueue}>
                                 {(leaveQueue) =>
                                     <div className="leaveQueueContainer">
                                         <p className="leaveQueueText">
-                                            {leaveQueueText}
                                             <span
                                                 className="leaveQueue"
                                                 onClick={() =>
-                                                    this.handleLeaveQueue(leaveQueue, refetch)
+                                                    this.handleLeaveQueue(leaveQueue, this.props.refetch)
                                                 }
                                             >
-                                            Leave Other Queue
+                                                retract your question from the other queue!
                                             </span>
                                         </p>
                                     </div>
                                 }
-                            </Mutation> */}
+                            </Mutation>
                         </div>
                         <div className="SessionJoinButton disabled">
                             <p><Icon name="plus" /> Join the Queue</p>

--- a/client/src/components/includes/SessionView.tsx
+++ b/client/src/components/includes/SessionView.tsx
@@ -23,6 +23,7 @@ query getDataForSession($sessionId: Int!, $courseId: Int!) {
             }
             questionsByAskerId {
                 nodes {
+                    questionId
                     timeEntered
                     status
                     sessionBySessionId {
@@ -240,6 +241,9 @@ class SessionView extends React.Component {
                             .filter((question) => question.status === 'unresolved')
                             .filter((question) => new Date(question.sessionBySessionId.endTime) >= new Date());
 
+                        // contains all the question ids from user's other in progess sessions
+                        var otherQuestionsId = otherQuestions.map((q) => q.questionId);
+
                         const userQuestions = data.apiGetCurrentUser.nodes[0].questionsByAskerId.nodes;
 
                         const lastAskedQuestion = userQuestions.length > 0 ?
@@ -308,7 +312,6 @@ class SessionView extends React.Component {
                                                 }
                                             </Mutation>
                                         }
-                                        {/* {console.log('questions associated w/ other sessions', otherQuestions)} */}
                                         <SessionQuestionsContainer
                                             isTA={data.apiGetCurrentUser.nodes[0].
                                                 courseUsersByUserId.nodes[0].role !== 'student'}
@@ -329,7 +332,7 @@ class SessionView extends React.Component {
                                             openingTime={this.getOpeningTime(
                                                 data.sessionBySessionId, data.courseByCourseId.queueOpenInterval)}
                                             haveAnotherQuestion={otherQuestions.length > 0}
-                                        // need to pass in more info as props: otherQuestions
+                                            otherQuestionsId={otherQuestionsId}
                                         />
                                     </React.Fragment>
                                 }

--- a/client/src/components/includes/SessionView.tsx
+++ b/client/src/components/includes/SessionView.tsx
@@ -308,6 +308,7 @@ class SessionView extends React.Component {
                                                 }
                                             </Mutation>
                                         }
+                                        {/* {console.log('questions associated w/ other sessions', otherQuestions)} */}
                                         <SessionQuestionsContainer
                                             isTA={data.apiGetCurrentUser.nodes[0].
                                                 courseUsersByUserId.nodes[0].role !== 'student'}
@@ -318,7 +319,7 @@ class SessionView extends React.Component {
                                             myUserId={data.apiGetCurrentUser.nodes[0].userId}
                                             triggerUndo={this.triggerUndo}
                                             refetch={refetch}
-                                            // this sets a ref, which allows a parent to call methods on a child.
+                                            // this sets a ref, which allows a parent to call methods on a child.   
                                             // Here, the parent can't access refetch, but the child can.
                                             ref={(ref) => this.questionsContainer = ref}
                                             isOpen={this.isOpen(
@@ -328,6 +329,7 @@ class SessionView extends React.Component {
                                             openingTime={this.getOpeningTime(
                                                 data.sessionBySessionId, data.courseByCourseId.queueOpenInterval)}
                                             haveAnotherQuestion={otherQuestions.length > 0}
+                                        // need to pass in more info as props: otherQuestions
                                         />
                                     </React.Fragment>
                                 }

--- a/client/src/components/types/appData.d.ts
+++ b/client/src/components/types/appData.d.ts
@@ -118,6 +118,7 @@ interface AppUserRole extends AppUser {
 interface AppUserRoleQuestions extends AppUserRole {
     questionsByAskerId: {
         nodes: [{
+            questionId: number;
             timeEntered: number;
             status: string;
             sessionBySessionId: AppSession;

--- a/client/src/styles/SplitView.less
+++ b/client/src/styles/SplitView.less
@@ -23,6 +23,20 @@ section.StudentSessionView {
     -webkit-overflow-scrolling: touch;
 }
 
+.SessionLeaveQueueMessage{
+    color: #ffffff;
+    background-color:#8d8d8d;
+    font-size: 16px;
+    padding: 12px 0px 12px 0px;
+    font-weight: 100;
+    margin-top: -13px; //this is - 13px, not -12px because it is fuzzy
+}
+
+.removeQuestionLeaveQueue{
+    font-weight: 400;
+    text-decoration: underline;
+}
+
 section.StudentSessionView::-webkit-scrollbar , aside.CalendarView::-webkit-scrollbar {
     display: none;
 }

--- a/client/src/styles/SplitView.less
+++ b/client/src/styles/SplitView.less
@@ -29,6 +29,7 @@ section.StudentSessionView {
     font-size: 16px;
     padding: 12px 0px 12px 0px;
     font-weight: 100;
+    cursor: pointer;
     margin-top: -13px; //this is - 13px, not -12px because it is fuzzy
 }
 


### PR DESCRIPTION
### Inside This PR 
* Allows user to click on the text that says "You are holding a spot in another active queue...." to remove their question in the other active queue. After, the join the queue button will be clickable and the other text will disappear.

### Test Plan
* Tested locally by adding joining a class's queue and then changing classes to get the "You are holding..." text to display, then pressed the text and added a question to the queue.
* Need a way for testing what other uses see when someone removes their question to join a different queue.

### Notes
* A list of question ids are passed into SessionQuestionsContainer, but we only remove the first index/first question id. There shouldn't be a case where the list has length greater than one, but if that ever comes up, we would need to either add a database call that updates the statuses given multiple question ids or loop through the list and use the single call multiple times.

### Breaking Changes 
- [ ] Database schema change (anything that changes Postgres)
- [X] I updated existing types in `/src/components/types/`
- [ ] Other change that could cause problems (Detailed in notes)

### Checklist
- [ ] My changes requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
