### PR TITLE
Use latest yarn

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -8,10 +8,10 @@ jobs:
       - uses: actions/checkout@master
       - name: Set up Node
         uses: actions/setup-node@v1
-      - name: Pin to Yarn 1.18
-        run: yarn policies set-version 1.18
+        with:
+          node-version: 10.x
       - name: Install and Build
-        run: yarn install --ignore-engines
+        run: yarn install
       - name: Lint client
         run: cd client && yarn tslint --project tsconfig.json -c tslint.json 'src/**/*.ts' 'src/**/*.tsx'
       - name: Lint server

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,7 @@
     "proxy": "http://localhost:3001",
     "engines": {
         "node": "10",
-        "yarn": "1.18.0"
+        "yarn": ">=1.19.1"
     },
     "dependencies": {
         "@nivo/bar": "^0.51.5",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "license": "ISC",
     "engines": {
         "node": "10",
-        "yarn": "1.18.0"
+        "yarn": ">=1.19.1"
     },
     "bugs": {
         "url": "https://github.com/cornell-dti/office-hours/issues"

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "types": "lib/index",
     "engines": {
         "node": "10",
-        "yarn": "1.18.0"
+        "yarn": ">=1.19.1"
     },
     "scripts": {
         "start": "ts-node index.ts",


### PR DESCRIPTION
### Summary

We pinned yarn to 1.18 in #147 since yarn 1.19 has a bug that randomly causes install to fail. Now yarn has released 1.19.1 and it's already widely available in many environments. Therefore, we should now target `>=1.19.1` instead.

### Test Plan

CI still passes.