### PR TITLE
Broken Class Id and Semester fix

### DIFF
--- a/client/src/components/App.tsx
+++ b/client/src/components/App.tsx
@@ -17,7 +17,7 @@ import { Loader } from 'semantic-ui-react';
 
 ReactGA.initialize('UA-123790900-1');
 
-const DEFAULT_COURSE_ID = String(window.localStorage.getItem('lastid') || 5);
+const DEFAULT_COURSE_ID = String(window.localStorage.getItem('lastid') || 8);
 
 const GET_USER_AND_COURSE = gql`
 query GetUserAndCourse($courseId: Int!) {

--- a/client/src/components/includes/CalendarHeader.tsx
+++ b/client/src/components/includes/CalendarHeader.tsx
@@ -69,7 +69,7 @@ class CalendarHeader extends React.Component {
                     {this.state.showCourses &&
                         <React.Fragment>
                             <ul className="courseMenu" tabIndex={1} onClick={() => this.setCourses(false)} >
-                                {this.props.allCoursesList.filter((c) => c.semester === 'FA19').map((course) =>
+                                {this.props.allCoursesList.filter((c) => c.semester === 'SP20').map((course) =>
                                     <li key={course.courseId}>
                                         <a
                                             href={'/course/' + course.courseId}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
Changed front-end to display only SP20 classes instead of FA19. Changed default class id (if user is new to QMI) from 5 to 8

### Inside This PR
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->
* fix the blank page attempting to display course 5, which is inactive
* changed "FA19" to "SP20" in CalendarHeader.tsx

### Notes <!-- Optional -->
<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Database schema change (anything that changes Postgres)
- [ ] I updated existing types in `/src/components/types/`
- [ ] Other change that could cause problems (Detailed in notes)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My changes requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
- [ ] I tested affected functionality
- [ ] I resolved any merge conflicts
- [ ] My PR is ready for review
