### PR TITLE
Fix Crash For No TAs Session

### DIFF
--- a/client/src/components/includes/SessionInformationHeader.tsx
+++ b/client/src/components/includes/SessionInformationHeader.tsx
@@ -13,15 +13,8 @@ class SessionInformationHeader extends React.Component {
         isDesktop: boolean,
     };
 
-    state: {
-        avatar: string
-    };
-
     constructor(props: {}) {
         super(props);
-        this.state = {
-            avatar: this.props.session.sessionTasBySessionId.nodes[0].userByUserId.computedAvatar
-        };
     }
 
     handleBackClick = () => {
@@ -31,6 +24,9 @@ class SessionInformationHeader extends React.Component {
     render() {
         const session = this.props.session;
         const tas = session.sessionTasBySessionId.nodes;
+        const avatar = tas[0] ?
+            tas[0].userByUserId.computedAvatar :
+            '/placeholder.png';
 
         const unresolvedQuestions = session.questionsBySessionId.nodes.filter((q) => q.status === 'unresolved');
         const userQuestions = unresolvedQuestions.filter((q) => q.userByAskerId.userId === this.props.myUserId);
@@ -42,12 +38,7 @@ class SessionInformationHeader extends React.Component {
                 <header className="DesktopSessionInformationHeader" >
                     <div className="Picture">
                         <img
-                            src={this.state.avatar}
-                            onError={
-                                (() => this.setState({
-                                    avatar: '/placeholder.png'
-                                }))
-                            }
+                            src={avatar}
                         />
                     </div>
                     <div className="Details">
@@ -94,12 +85,7 @@ class SessionInformationHeader extends React.Component {
                         </div>
                         <div className="Picture">
                             <img
-                                src={this.state.avatar}
-                                onError={
-                                    (() => this.setState({
-                                        avatar: '/placeholder.png'
-                                    }))
-                                }
+                                src={avatar}
                             />
                         </div>
                     </div>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

### Inside This PR
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->
* When professors create a new office hour and don't select any TAs for that session, the front-end was accessing the first index of an empty list in SessionInformationHeader. In previous semesters, this did not cause the site to crash so it was dealt with previously.
* The fix was to deal with it on the front-end by removing the component's state because it is unnecessary. Logic was added to deal with an empty list, so now we are not going out of bounds. 

### Notes <!-- Optional -->
This used to not break before but at the start of SP20, it suddenly broke. The cause was not determined, but the fix was to update SessionInformationHeader to deal with the backend case mentioned above.

### Breaking Changes
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Database schema change (anything that changes Postgres)
- [ ] I updated existing types in `/src/components/types/`
- [ ] Other change that could cause problems (Detailed in notes)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My changes requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
- [X] I tested affected functionality
- [X] I resolved any merge conflicts
- [X] My PR is ready for review
