### PR TITLE
No longer pin yarn to 1.18

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -8,8 +8,6 @@ jobs:
       - uses: actions/checkout@master
       - name: Set up Node
         uses: actions/setup-node@v1
-      - name: Pin to Yarn 1.18
-        run: yarn policies set-version 1.18
       - name: Install and Build
         run: yarn install
       - name: Lint client

--- a/client/package.json
+++ b/client/package.json
@@ -4,8 +4,7 @@
     "private": true,
     "proxy": "http://localhost:3001",
     "engines": {
-        "node": "10",
-        "yarn": "1.18.0"
+        "node": "10"
     },
     "dependencies": {
         "@nivo/bar": "^0.59.2",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

### Inside This PR

This diff no longer pins Yarn 1.18 in develop-firebase branch. This is introduced when Yarn 1.19.0 has a breaking change. Now the latest yarn fixed the problem, we no longer need this.

### Notes <!-- Optional -->
<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Database schema change (anything that changes Postgres)
- [ ] I updated existing types in `/src/components/types/`
- [ ] Other change that could cause problems (Detailed in notes)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My changes requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
- [x] I tested affected functionality
- [x] I resolved any merge conflicts
- [x] My PR is ready for review
