### PR TITLE
3110 hours fix

### DIFF
--- a/client/src/components/includes/ProfessorOHInfo.tsx
+++ b/client/src/components/includes/ProfessorOHInfo.tsx
@@ -376,9 +376,10 @@ class ProfessorOHInfo extends React.Component {
                                 // Manually added showTimeSelectOnly property to react-datepicker/index.d.ts
                                 // Will not compile if removed
                                 showTimeSelectOnly={true}
-                                timeIntervals={30}
-                                dateFormat="LT"
+                                timeIntervals={10}
+                                dateFormat="h:mm a"
                                 placeholderText="12:00 PM"
+                                readOnly={true}
                             />
                         </div >
                         <span className="shift">
@@ -392,11 +393,12 @@ class ProfessorOHInfo extends React.Component {
                                 // Manually added showTimeSelectOnly property to react-datepicker/index.d.ts
                                 // Will not compile if removed
                                 showTimeSelectOnly={true}
-                                timeIntervals={30}
+                                timeIntervals={10}
                                 dateFormat="LT"
                                 minTime={this.state.startTime || moment().startOf('day')}
                                 maxTime={moment().endOf('day')}
                                 placeholderText="2:00 PM"
+                                readOnly={true}
                             />
                         </div >
                         <Checkbox

--- a/client/src/components/includes/ProfessorOHInfo.tsx
+++ b/client/src/components/includes/ProfessorOHInfo.tsx
@@ -377,7 +377,7 @@ class ProfessorOHInfo extends React.Component {
                                 // Will not compile if removed
                                 showTimeSelectOnly={true}
                                 timeIntervals={10}
-                                dateFormat="h:mm a"
+                                dateFormat="LT"
                                 placeholderText="12:00 PM"
                                 readOnly={true}
                             />

--- a/client/src/components/includes/ProfessorOHInfo.tsx
+++ b/client/src/components/includes/ProfessorOHInfo.tsx
@@ -379,7 +379,6 @@ class ProfessorOHInfo extends React.Component {
                                 timeIntervals={30}
                                 dateFormat="LT"
                                 placeholderText="12:00 PM"
-                                readOnly={true}
                             />
                         </div >
                         <span className="shift">
@@ -398,7 +397,6 @@ class ProfessorOHInfo extends React.Component {
                                 minTime={this.state.startTime || moment().startOf('day')}
                                 maxTime={moment().endOf('day')}
                                 placeholderText="2:00 PM"
-                                readOnly={true}
                             />
                         </div >
                         <Checkbox

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,11 +2,13 @@ import * as express from 'express';
 import postgraphile from 'postgraphile';
 import * as passport from 'passport';
 import * as sslRedirect from 'heroku-ssl-redirect';
+import * as dotenv from 'dotenv';
 
 var session = require('cookie-session');
 var request = require('request');
 var jwt = require('jsonwebtoken');
 var url = require('url');
+dotenv.config();
 
 const app = express();
 app.use(sslRedirect());
@@ -185,7 +187,7 @@ app.use(function (req, res, next) {
     next();
 });
 
-app.use(postgraphile(process.env.DATABASE_URL || 'postgres://localhost:5432', {
+app.use(postgraphile(process.env.DATABASE_URL || `postgres://${process.env.POSTGRES_USERNAME}:${process.env.POSTGRES_PASSWORD}@${process.env.POSTGRES_HOSTNAME}:${process.env.POSTGRES_PORT}/${process.env.POSTGRES_DBNAME}`, {
     graphiql: true,
     graphqlRoute: '/__gql/graphql',
     graphiqlRoute: '/__gql/graphiql',

--- a/server/package.json
+++ b/server/package.json
@@ -29,6 +29,7 @@
         "body-parser": "^1.18.2",
         "command-line-args": "^5.0.2",
         "cookie-session": "^2.0.0-beta.3",
+        "dotenv": "^8.2.0",
         "express": "^4.16.4",
         "express-graphql": "^0.6.12",
         "express-session": "^1.15.6",
@@ -37,6 +38,7 @@
         "graphql-subscriptions": "^1.0.0",
         "graphql-tools": "^4.0.2",
         "heroku-ssl-redirect": "^0.0.4",
+        "install": "^0.13.0",
         "jsonwebtoken": "^8.3.0",
         "nodemon": "^1.12.1",
         "passport": "^0.4.0",
@@ -48,10 +50,10 @@
         "tslint": "^5.11.0"
     },
     "devDependencies": {
-        "@types/node": "^10.12.0",
         "@types/cookie-session": "^2.0.36",
         "@types/express": "^4.16.0",
         "@types/express-session": "^1.15.11",
+        "@types/node": "^10.12.0",
         "@types/passport": "^0.4.6",
         "@types/passport-google-oauth2": "^0.1.2",
         "apollo-server-express": "^2.1.0",

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1070,6 +1070,11 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
@@ -1765,6 +1770,11 @@ inherits@2.0.3:
 ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
+
+install@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/install/-/install-0.13.0.tgz#6af6e9da9dd0987de2ab420f78e60d9c17260776"
+  integrity sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==
 
 invert-kv@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
Allows you to select office hours in 10-minute intervals. Solves the issue of 3110 office hours starting at 4:40. Adds support for .env to store prostgres credentials to prevent any further passwords from being accidentally being pushed.

### Inside This PR
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->
* change office hour increment intervals from 30 to 10 minutes in ProfessorOHInfo
* add dotenv package to scan for a .env file containing postgres login credentials in the server/ directory

### Notes <!-- Optional -->
<!--- List any important or subtle points, future considerations, or other items of note. -->
* WILL break for those running the server locally. Will require you to create an .env file in server/ to store & protect local postgres db login credentials.
* Probably should also add support for manually typing in hours, with time validation sometime in the future.

### Breaking Changes
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Database schema change (anything that changes Postgres)
- [ ] I updated existing types in `/src/components/types/`
- [x] Other change that could cause problems (Detailed in notes)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My changes require a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
- [x] I tested affected functionality
- [x] I resolved any merge conflicts
- [x] My PR is ready for review
