### PR TITLE
Support creating and editing sessions in ProfessorOHInfo

### DIFF
--- a/client/src/components/includes/CalendarHeader.tsx
+++ b/client/src/components/includes/CalendarHeader.tsx
@@ -106,13 +106,13 @@ class CalendarHeader extends React.Component {
                 </div>
                 {this.state.showMenu && (
                     <ul className="logoutMenu" onClick={() => this.setMenu(false)} >
+                        {/* RYAN_TODO: figure out what's the purpose of this code. */}
                         {/* {this.props.isTa &&
                             <React.Fragment>
                                 <li>Cancel Session</li>
                                 <li>Change Session</li>
                             </React.Fragment>
                         } */}
-                        {/* RYAN_TODO fix logging out */}
                         <li onClick={() => logOut()}> <span><Icon name="sign out" /></span>Log Out</li>
                         <li>
                             <a href="https://goo.gl/forms/7ozmsHfXYWNs8Y2i1" target="_blank" rel="noopener noreferrer">

--- a/client/src/firebase.ts
+++ b/client/src/firebase.ts
@@ -19,6 +19,8 @@ const firestore = firebase.firestore(app); // Initialize firestore
 const auth = firebase.auth(app); // Initialize firebase auth
 const loggedIn$ = authState(auth).pipe(filter(user => !!user)); // Observable only return when user is logged in.
 
-export { app, auth, firestore, collectionData, loggedIn$ };
+const Timestamp = firebase.firestore.Timestamp;
+
+export { app, auth, firestore, collectionData, loggedIn$, Timestamp };
 
 export default firebase;


### PR DESCRIPTION
Added support for creating and editing a session/series, to various levels.

### Inside This PR

- Creation/Editing support for a standalone session is fully ready.
- Creation/Editing support for series and series-related session is halfway there.

### Notes <!-- Optional -->

The reason for the half-way done series support is follows:

- The old backend generates sessions based on the series. i.e. series is used as template.
- To make it worse, the logic is different between creating and editing series.

Relevant code of old backend on master is linked below:

https://github.com/cornell-dti/office-hours/blob/ae7e5063d4ee6b466e420644ab24b14d548ce500/server/database/mock_database.sql#L567-L610
https://github.com/cornell-dti/office-hours/blob/ae7e5063d4ee6b466e420644ab24b14d548ce500/server/database/mock_database.sql#L776-L816

(Those blocks are massive :(( )

Supporting these behavior is more involved, and it's better to do it in a future diff. What's important is that now we can create and edit basic series, so we can do more testing!

### Breaking Changes
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Database schema change (anything that changes Postgres)
- [ ] I updated existing types in `/src/components/types/`
- [ ] Other change that could cause problems (Detailed in notes)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My changes requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
- [x] I tested affected functionality
- [x] I resolved any merge conflicts
- [x] My PR is ready for review
