### PR TITLE
Make course users take string id for related documents

### DIFF
--- a/client/src/components/App.tsx
+++ b/client/src/components/App.tsx
@@ -38,7 +38,7 @@ const PrivateRoute = ({ component, requireProfessor, ...rest }: any) => {
     // 1: Not logged in
     // 2: Logged in
 
-    const courseId = requireProfessor ? rest.computedMatch.params.courseId : undefined;
+    const courseId: string = requireProfessor ? rest.computedMatch.params.courseId : DEFAULT_COURSE_ID;
 
     const [isLoggedIn, setIsLoggedIn] = React.useState<0 | 1 | 2>(0);
     const cu = useMyCourseUser(courseId);

--- a/client/src/components/includes/ProfessorRolesTable.tsx
+++ b/client/src/components/includes/ProfessorRolesTable.tsx
@@ -26,8 +26,8 @@ const RoleDropdown = ({ default: role, courseUserId, userId, courseId }: {
             onChange={(e, newValue) => {
                 const update = {
                     role: newValue.value,
-                    courseId: firestore.doc(`courses/${courseId}`),
-                    userId: firestore.doc(`users/${userId}`)
+                    courseId,
+                    userId,
                 };
                 firestore.collection('courseUsers').doc(courseUserId).update(update);
             }}
@@ -37,7 +37,7 @@ const RoleDropdown = ({ default: role, courseUserId, userId, courseId }: {
 
 type columnT = 'firstName' | 'lastName' | 'email' | 'role';
 
-type enrichedFireCourseUser = FireUser & { role: FireCouseRole; courseUserId: string };
+type enrichedFireCourseUser = FireUser & { role: FireCourseRole; courseUserId: string };
 
 export default (props: { courseId: string }) => {
     const [direction, setDirection] = useState<'descending' | 'ascending'>('ascending');
@@ -53,14 +53,14 @@ export default (props: { courseId: string }) => {
             const courseUsers$ = collection(
                 firestore
                     .collection('courseUsers')
-                    .where('courseId', '==', firestore.doc('courses/' + props.courseId))
+                    .where('courseId', '==', props.courseId)
             );
 
             const users$ = courseUsers$.pipe(switchMap(courseUsers =>
                 combineLatest(...courseUsers.map(courseUserDocument => {
                     const courseUserId = courseUserDocument.id;
                     const { userId, role } = courseUserDocument.data() as FireCourseUser;
-                    return docData<FireUser>(firestore.doc(userId.path), 'userId').pipe(
+                    return docData<FireUser>(firestore.doc(`users/${userId}`), 'userId').pipe(
                         map(u => ({ ...u, role, courseUserId }))
                     );
                 }))

--- a/client/src/components/pages/ProfessorView.tsx
+++ b/client/src/components/pages/ProfessorView.tsx
@@ -51,14 +51,14 @@ const ProfessorView = (props: {
             const courseUsers$: Observable<FireCourseUser[]> = collectionData(
                 firestore
                     .collection('courseUsers')
-                    .where('courseId', '==', firestore.doc('courses/' + courseId))
+                    .where('courseId', '==', courseId)
                     .where('role', 'in', ['professor', 'ta']),
                 'courseUserId'
             );
 
             const users$ = courseUsers$.pipe(switchMap(courseUsers =>
                 combineLatest(...courseUsers.map(courseUser =>
-                    docData<FireUser>(firestore.doc(courseUser.userId.path), 'userId').pipe(
+                    docData<FireUser>(firestore.doc(`users/${courseUser.userId}`), 'userId').pipe(
                         map(u => ({ ...u, role: courseUser.role }))
                     )
                 ))

--- a/client/src/components/types/fireData.d.ts
+++ b/client/src/components/types/fireData.d.ts
@@ -38,12 +38,12 @@ interface FireCourse {
     charLimit: number;
 }
 
-type FireCouseRole = 'professor' | 'ta' | 'student';
+type FireCourseRole = 'professor' | 'ta' | 'student';
 
 interface FireCourseUser {
-    courseId: firebase.firestore.DocumentReference;
-    userId: firebase.firestore.DocumentReference;
-    role: FireCouseRole;
+    courseId: string;
+    userId: string;
+    role: FireCourseRole;
     courseUserId: string;
 }
 


### PR DESCRIPTION
Part of the initiative to convert everything to string id.

### Breaking Changes
<!-- Put an `x` in all the boxes that apply: -->
- [x] Database schema change (anything that changes Postgres)
- [x] I updated existing types in `/src/components/types/`
- [ ] Other change that could cause problems (Detailed in notes)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My changes requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
- [x] I tested affected functionality
- [x] I resolved any merge conflicts
- [x] My PR is ready for review
