### PR TITLE
Introduce `useQueryWithLoading` for calendar sessions

### DIFF
--- a/client/src/components/includes/CalendarSessions.tsx
+++ b/client/src/components/includes/CalendarSessions.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
+import { Loader } from 'semantic-ui-react';
 import { groupBy } from 'lodash';
 
 import CalendarSessionCard from './CalendarSessionCard';
-import { useQuery } from '../../firehooks';
+import { useQueryWithLoading } from '../../firehooks';
 import { firestore } from '../../firebase';
 
 const getQuery = (courseId: string) => firestore
@@ -27,9 +28,9 @@ const CalendarSessions = (props: {
         return 'Upcoming';
     };
 
-    const sessions = useQuery<FireSession>(props.course.courseId, getQuery, 'sessionId');
+    const sessions = useQueryWithLoading<FireSession>(props.course.courseId, getQuery, 'sessionId');
 
-    const sessionCards = sessions.map(session => {
+    const sessionCards = sessions && sessions.map(session => {
         // RYAN_TODO
         // const unresolvedQuestions = 0;
         // session.questionsBySessionId.nodes.filter((q) => q.status === 'unresolved');
@@ -54,7 +55,8 @@ const CalendarSessions = (props: {
     const groupedCards = sessionCards && groupBy(sessionCards, (card: React.ReactElement) => card.props.status);
     return (
         <div className="CalendarSessions">
-            {sessions.length === 0 && <React.Fragment>
+            {sessions === null && <Loader active={true} content={'Loading'} />}
+            {sessions !== null && sessions.length === 0 && <React.Fragment>
                 <p className="noHoursHeading">No Office Hours</p>
                 <p className="noHoursBody">No office hours are scheduled for today.</p>
             </React.Fragment>}


### PR DESCRIPTION
Added a hook that can distinguish between loading state and empty result state.
Transformed the existing `useQuery` hook to simply call it.

### Notes <!-- Optional -->
<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Database schema change (anything that changes Postgres)
- [ ] I updated existing types in `/src/components/types/`
- [ ] Other change that could cause problems (Detailed in notes)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My changes requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
- [x] I tested affected functionality
- [x] I resolved any merge conflicts
- [x] My PR is ready for review
