### PR TITLE
Filter sessions by date

### DIFF
--- a/client/src/components/includes/CalendarDaySelect.tsx
+++ b/client/src/components/includes/CalendarDaySelect.tsx
@@ -12,7 +12,7 @@ const monthNames = ['January', 'February', 'March', 'April', 'May', 'June',
 class CalendarDaySelect extends React.Component {
 
     props!: {
-        callback: Function;
+        callback: (time: number) => void;
     };
 
     state!: {

--- a/client/src/components/includes/CalendarSessions.tsx
+++ b/client/src/components/includes/CalendarSessions.tsx
@@ -1,19 +1,12 @@
 import * as React from 'react';
-import { Loader } from 'semantic-ui-react';
 import { groupBy } from 'lodash';
 
 import CalendarSessionCard from './CalendarSessionCard';
-import { useQueryWithLoading } from '../../firehooks';
-import { firestore } from '../../firebase';
 
-const getQuery = (courseId: string) => firestore
-    .collection('sessions')
-    // RYAN_TODO filter based on today's date.
-    .where('courseId', '==', courseId);
-
-const CalendarSessions = (props: {
+const CalendarSessions = ({ activeSession, course, sessions, callback }: {
     activeSession?: FireSession;
     course: FireCourse;
+    sessions: FireSession[];
     callback: (sessionId: string) => void;
 }) => {
     const labelSession = (session: FireSession, intervalMs: number) => {
@@ -28,9 +21,7 @@ const CalendarSessions = (props: {
         return 'Upcoming';
     };
 
-    const sessions = useQueryWithLoading<FireSession>(props.course.courseId, getQuery, 'sessionId');
-
-    const sessionCards = sessions && sessions.map(session => {
+    const sessionCards = sessions.map(session => {
         // RYAN_TODO
         // const unresolvedQuestions = 0;
         // session.questionsBySessionId.nodes.filter((q) => q.status === 'unresolved');
@@ -46,17 +37,16 @@ const CalendarSessions = (props: {
                 numAhead={numAhead}
                 session={session}
                 key={session.sessionId}
-                callback={props.callback}
-                active={props.activeSession ? props.activeSession.sessionId === session.sessionId : false}
-                status={labelSession(session, props.course.queueOpenInterval * 1000)}
+                callback={callback}
+                active={activeSession ? activeSession.sessionId === session.sessionId : false}
+                status={labelSession(session, course.queueOpenInterval * 1000)}
             />
         );
     });
     const groupedCards = sessionCards && groupBy(sessionCards, (card: React.ReactElement) => card.props.status);
     return (
         <div className="CalendarSessions">
-            {sessions === null && <Loader active={true} content={'Loading'} />}
-            {sessions !== null && sessions.length === 0 && <React.Fragment>
+            {sessions.length === 0 && <React.Fragment>
                 <p className="noHoursHeading">No Office Hours</p>
                 <p className="noHoursBody">No office hours are scheduled for today.</p>
             </React.Fragment>}

--- a/client/src/components/includes/CalendarView.tsx
+++ b/client/src/components/includes/CalendarView.tsx
@@ -5,52 +5,51 @@ import CalendarHeader from './CalendarHeader';
 import CalendarDaySelect from './CalendarDaySelect';
 import CalendarSessions from './CalendarSessions';
 
-class CalendarView extends React.Component {
-    props!: {
-        session?: FireSession;
-        sessionCallback: (sessionId: string) => void;
-        course?: FireCourse;
-        courseUser?: FireCourseUser;
-    };
+import { firestore } from '../../firebase';
+import { useQueryWithLoading } from '../../firehooks';
+import { datePlus } from '../../utilities/date';
 
-    state!: {
-        selectedDateEpoch: number;
-        userId?: string;
-    };
+type Props = {
+    session?: FireSession;
+    sessionCallback: (sessionId: string) => void;
+    course?: FireCourse;
+    courseUser?: FireCourseUser;
+};
 
-    constructor(props: {}) {
-        super(props);
-        this.state = { selectedDateEpoch: new Date().setHours(0, 0, 0, 0) };
-    }
+const getQuery = (courseId: string) => firestore.collection('sessions').where('courseId', '==', courseId);
 
-    handleDateClick = (newDateEpoch: number) => {
-        this.setState({ selectedDateEpoch: newDateEpoch });
-    };
+const ONE_DAY = 24 /* hours */ * 60 /* minutes */ * 60 /* seconds */ * 1000 /* millis */;
 
-    render() {
-        // let selectedDate = new Date(this.state.selectedDateEpoch);
+export default ({ session, sessionCallback, course, courseUser }: Props) => {
+    const [selectedDateEpoch, setSelectedDate] = React.useState(new Date().setHours(0, 0, 0, 0));
+    const selectedDate = new Date(selectedDateEpoch);
 
-        return (
-            <aside className="CalendarView">
-                <CalendarHeader
-                    currentCourseCode={(this.props.course && this.props.course.code) || 'Loading'}
-                    role={(this.props.courseUser && this.props.courseUser.role)}
-                // avatar={data.apiGetCurrentUser && data.apiGetCurrentUser.nodes[0].computedAvatar}
+    const sessions = useQueryWithLoading<FireSession>(
+        (course && course.courseId) || '', getQuery, 'sessionId'
+    );
+    const filteredSessions = sessions && sessions.filter(session =>
+        selectedDate < session.startTime.toDate()
+        && session.endTime.toDate() < datePlus(selectedDate, ONE_DAY)
+    );
+
+    return (
+        <aside className="CalendarView">
+            <CalendarHeader
+                currentCourseCode={(course && course.code) || 'Loading'}
+                role={(courseUser && courseUser.role)}
+            />
+            <CalendarDaySelect callback={setSelectedDate} />
+            {course ?
+                <CalendarSessions
+                    activeSession={session}
+                    callback={sessionCallback}
+                    course={course}
+                    sessions={filteredSessions || []}
                 />
-                <CalendarDaySelect callback={this.handleDateClick} />
-                {this.props.course ?
-                    <CalendarSessions
-                        activeSession={this.props.session}
-                        callback={this.props.sessionCallback}
-                        course={this.props.course}
-                    />
-                    : <div className="CalendarSessions">
-                        <Loader active={true} content={'Loading'} />
-                    </div>
-                }
-            </aside>
-        );
-    }
-}
-
-export default CalendarView;
+                : <div className="CalendarSessions">
+                    <Loader active={true} content={'Loading'} />
+                </div>
+            }
+        </aside>
+    );
+};


### PR DESCRIPTION
On the client side, we still fetch all the sessions, but we filter it by date to feed into CalendarSessions component.
Since we are only fetching data for one course, and we don't pull the entire giant list, there won't be big performance hit.
On the bright side, it makes implementation significantly easier!

### Notes <!-- Optional -->
<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Database schema change (anything that changes Postgres)
- [ ] I updated existing types in `/src/components/types/`
- [ ] Other change that could cause problems (Detailed in notes)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My changes requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
- [x] I tested affected functionality
- [x] I resolved any merge conflicts
- [x] My PR is ready for review
