### PR TITLE
Fix React hooks linter warning in professsor calendar view

### DIFF
--- a/client/src/firehooks.ts
+++ b/client/src/firehooks.ts
@@ -60,7 +60,7 @@ export const useQueryWithLoading = <T, P=string>(
 };
 export const useQuery = <T, P=string>(
     queryParameter: P, getQuery: (parameter: P) => firebase.firestore.Query, idField: string
-): T[] => useQuery(queryParameter, getQuery, idField) || [];
+): T[] => useQueryWithLoading(queryParameter, getQuery, idField) || [];
 
 // Here be dragons. The functions below this line may have unexpected
 // behaviors when the values they rely on change. I'm not sure.


### PR DESCRIPTION
Use the better `useQuery` hooks to replace the existing hacky solution.

<!-- Provide a general summary of your changes in the Title above -->

### Inside This PR
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->
*

### Notes <!-- Optional -->
<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Database schema change (anything that changes Postgres)
- [ ] I updated existing types in `/src/components/types/`
- [ ] Other change that could cause problems (Detailed in notes)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My changes requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
- [x] I tested affected functionality
- [x] I resolved any merge conflicts
- [x] My PR is ready for review
