### PR TITLE
Store professor and ta list in `FireCourse`

### DIFF
--- a/client/src/components/types/fireData.d.ts
+++ b/client/src/components/types/fireData.d.ts
@@ -34,6 +34,8 @@ interface FireCourse {
     queueOpenInterval: number;
     semester: string;
     startDate: FireTimestamp;
+    professors: readonly string[];
+    tas: readonly string[];
     courseId: string;
     charLimit: number;
 }

--- a/client/src/firebasefunctions.ts
+++ b/client/src/firebasefunctions.ts
@@ -28,13 +28,7 @@ export const userUpload = (user: firebase.User | null, db: firebase.firestore.Fi
       photoUrl,
       createdAt,
       lastActivityAt: firestore.FieldValue.serverTimestamp()
-    })
-      .then(function () {
-        // Successful upload
-      })
-      .catch(function (error: string) {
-        // Unsuccessful upload
-      });
+    }).catch(() => console.error('Unable to upload user.'));
   }
 };
 


### PR DESCRIPTION
Firebase security rules do not let you do query; instead, you can only get document by id or check exists. Our current setup requires to perform a query in `courseUsers` collection to check whether current auth user is a professor of a certain class, which is unachievable with firebase security rule.
The only solution is to duplicate the data in `courses` collection. Since number of professors and tas should be small, it should not create a huge performance overhead. It even introduces a benefit: now with the duplicated data, the query in `ProfessorRolesTable` can be implemented more efficiently.

<!-- Provide a general summary of your changes in the Title above -->

### Inside This PR
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->


### Notes <!-- Optional -->
<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes
<!-- Put an `x` in all the boxes that apply: -->
- [x] Database schema change (anything that changes Postgres)
- [x] I updated existing types in `/src/components/types/`
- [ ] Other change that could cause problems (Detailed in notes)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My changes requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
- [x] I tested affected functionality
- [x] I resolved any merge conflicts
- [x] My PR is ready for review
