### PR TITLE
More efficient firebase hooks by reusing existing data

### DIFF
--- a/client/src/components/includes/CalendarHeader.tsx
+++ b/client/src/components/includes/CalendarHeader.tsx
@@ -1,110 +1,82 @@
 import * as React from 'react';
 import { Icon } from 'semantic-ui-react';
 
-import { Subscription } from 'rxjs';
 import { logOut } from '../../firebasefunctions';
-import { fireCoursesSingletonObservable } from '../../firehooks';
+import { useMyCourses } from '../../firehooks';
+
+import { CURRENT_SEMESTER } from '../../constants';
 
 import QMeLogo from '../../media/QLogo2.svg';
 import chevron from '../../media/chevron.svg'; // Replace with dropdown cheveron
 
-class CalendarHeader extends React.Component {
-    props!: {
-        currentCourseCode: string;
-        role?: string;
-        avatar?: string;
-    };
+type Props = {
+    readonly currentCourseCode: string;
+    readonly role?: FireCourseRole;
+    readonly avatar?: string;
+};
 
-    state!: {
-        showMenu: boolean;
-        showCourses: boolean;
-        courses: FireCourse[];
-        userId?: string;
-    };
+export default ({ currentCourseCode, role, avatar }: Props): React.ReactElement => {
+    const [showMenu, setShowMenu] = React.useState(false);
+    const [showCourses, setShowCourses] = React.useState(false);
+    const courses = useMyCourses();
 
-    private readonly coursesSubscription: Subscription;
-
-    constructor(props: {}) {
-        super(props);
-        this.state = { showMenu: false, showCourses: false, courses: fireCoursesSingletonObservable.get() };
-        this.coursesSubscription = fireCoursesSingletonObservable.subscribe(courses => this.setState({ courses }));
-    }
-
-    componentWillUnmount() {
-        this.coursesSubscription.unsubscribe();
-    }
-
-    setMenu = (status: boolean) => {
-        this.setState({ showMenu: status });
-    };
-
-    setCourses = (status: boolean) => {
-        this.setState({ showCourses: status });
-    };
-
-    render() {
-        return (
-            <div className="Header">
-                <div className="LogoContainer">
-                    <img src={QMeLogo} className="QMeLogo" alt="Queue Me In Logo" />
-                </div>
-                <div className="CalendarHeader" onClick={() => this.setCourses(!this.state.showCourses)}>
-                    <span>
-                        <span>{this.props.currentCourseCode}</span>
-                        {this.props.role && this.props.role === 'ta' && <span className="TAMarker">TA</span>}
-                        {this.props.role && this.props.role === 'professor' &&
-                            <span className="TAMarker Professor">PROF</span>}
-                        <span className="CourseSelect">
-                            <img src={chevron} alt="Course Select" className="RotateDown" />
-                        </span>
+    return (
+        <div className="Header">
+            <div className="LogoContainer">
+                <img src={QMeLogo} className="QMeLogo" alt="Queue Me In Logo" />
+            </div>
+            <div className="CalendarHeader" onClick={() => setShowCourses(shown => !shown)}>
+                <span>
+                    <span>{currentCourseCode}</span>
+                    {role && role === 'ta' && <span className="TAMarker">TA</span>}
+                    {role && role === 'professor' && <span className="TAMarker Professor">PROF</span>}
+                    <span className="CourseSelect">
+                        <img src={chevron} alt="Course Select" className="RotateDown" />
                     </span>
-                    {this.props.avatar &&
-                        <img
-                            className="mobileHeaderFace"
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                this.setMenu(!this.state.showMenu);
-                            }}
-                            src={this.props.avatar}
-                            alt="User avatar"
-                        />
-                    }
-                    {this.state.showCourses &&
-                        <ul className="courseMenu" tabIndex={1} onClick={() => this.setCourses(false)} >
-                            {/* RYAN_TODO factor this out to a global settings/config thing on firebase */}
-                            {this.state.courses.filter((c) => c.semester === 'FA19').map((course) =>
-                                <li key={course.courseId}>
-                                    <a
-                                        href={'/course/' + course.courseId}
-                                        onClick={() =>
-                                            window.localStorage.setItem('lastid', String(course.courseId))}
-                                    > {course.code}
-                                    </a>
-                                </li>
-                            )}
-                        </ul>
-                    }
-                </div>
-                {this.state.showMenu && (
-                    <ul className="logoutMenu" onClick={() => this.setMenu(false)} >
-                        {/* RYAN_TODO: figure out what's the purpose of this code. */}
-                        {/* {this.props.isTa &&
+                </span>
+                {avatar &&
+                    <img
+                        className="mobileHeaderFace"
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            setShowMenu(shown => !shown);
+                        }}
+                        src={avatar}
+                        alt="User avatar"
+                    />
+                }
+                {showCourses &&
+                    <ul className="courseMenu" tabIndex={1} onClick={() => setShowCourses(false)} >
+                        {courses.filter((c) => c.semester === CURRENT_SEMESTER).map((course) =>
+                            <li key={course.courseId}>
+                                <a
+                                    href={'/course/' + course.courseId}
+                                    onClick={() =>
+                                        window.localStorage.setItem('lastid', String(course.courseId))}
+                                > {course.code}
+                                </a>
+                            </li>
+                        )}
+                    </ul>
+                }
+            </div>
+            {showMenu && (
+                <ul className="logoutMenu" onClick={() => setShowMenu(false)} >
+                    {/* RYAN_TODO: figure out what's the purpose of this code. */}
+                    {/* {this.props.isTa &&
                             <React.Fragment>
                                 <li>Cancel Session</li>
                                 <li>Change Session</li>
                             </React.Fragment>
                         } */}
-                        <li onClick={() => logOut()}> <span><Icon name="sign out" /></span>Log Out</li>
-                        <li>
-                            <a href="https://goo.gl/forms/7ozmsHfXYWNs8Y2i1" target="_blank" rel="noopener noreferrer">
-                                <span><Icon name="edit" /></span>Send Feedback
-                            </a>
-                        </li>
-                    </ul>
-                )}
-            </div>
-        );
-    }
-}
-
-export default CalendarHeader;
+                    <li onClick={() => logOut()}> <span><Icon name="sign out" /></span>Log Out</li>
+                    <li>
+                        <a href="https://goo.gl/forms/7ozmsHfXYWNs8Y2i1" target="_blank" rel="noopener noreferrer">
+                            <span><Icon name="edit" /></span>Send Feedback
+                        </a>
+                    </li>
+                </ul>
+            )}
+        </div>
+    );
+};

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -1,0 +1,1 @@
+export const CURRENT_SEMESTER = 'SP20';


### PR DESCRIPTION
A few diffs ago, I setup the singleton observable infra. The idea is that the query is only performed once, and make other resources that depend on this data subscribe to a single source of truth.
This diff finishes up the performance optimization inside `firehook.ts`. It caches all the fetches courses, and only do filter based on already fetched data.

### Notes <!-- Optional -->
<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Database schema change (anything that changes Postgres)
- [ ] I updated existing types in `/src/components/types/`
- [ ] Other change that could cause problems (Detailed in notes)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My changes requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
- [x] I tested affected functionality
- [x] I resolved any merge conflicts
- [x] My PR is ready for review
