### PR TITLE
Pre-fetch tags for questions in SessionView

### DIFF
--- a/client/src/components/includes/SessionQuestionsContainer.tsx
+++ b/client/src/components/includes/SessionQuestionsContainer.tsx
@@ -8,6 +8,7 @@ const SHOW_FEEDBACK_QUEUE = 4;
 type Props = {
     readonly isTA: boolean;
     readonly questions: readonly FireQuestion[];
+    readonly tags: { readonly [tagId: string]: FireTag };
     readonly myUserId: string;
     readonly handleJoinClick: Function;
     readonly triggerUndo: Function;
@@ -103,6 +104,7 @@ const SessionQuestionsContainer = (props: Props) => {
                     <SessionQuestion
                         key={myQuestion[0].questionId}
                         question={myQuestion[0]}
+                        tags={props.tags}
                         index={questions.indexOf(myQuestion[0])}
                         isTA={props.isTA}
                         includeRemove={true}
@@ -118,6 +120,7 @@ const SessionQuestionsContainer = (props: Props) => {
                     <SessionQuestion
                         key={question.questionId}
                         question={question}
+                        tags={props.tags}
                         index={i}
                         isTA={props.isTA}
                         includeRemove={false}

--- a/client/src/components/includes/SessionView.tsx
+++ b/client/src/components/includes/SessionView.tsx
@@ -5,6 +5,7 @@ import SessionInformationHeader from '../includes/SessionInformationHeader';
 import SessionQuestionsContainer from '../includes/SessionQuestionsContainer';
 
 import { Icon } from 'semantic-ui-react';
+import { useCourseTags } from '../../firehooks';
 // import SessionAlertModal from './SessionAlertModal';
 
 type Props = {
@@ -34,6 +35,7 @@ type AbsentState = {
 const SessionViewInHooks = (
     { course, session, questions, isDesktop, backCallback, joinCallback, user, courseUser }: Props
 ) => {
+    const tags = useCourseTags(course.courseId);
     const [
         { undoAction, undoName, undoQuestionId, timeoutId },
         setUndoState
@@ -187,6 +189,7 @@ const SessionViewInHooks = (
             <SessionQuestionsContainer
                 isTA={courseUser.role !== 'student'}
                 questions={questions.filter(q => q.status === 'unresolved' || q.status === 'assigned')}
+                tags={tags}
                 handleJoinClick={joinCallback}
                 myUserId={user.userId}
                 triggerUndo={triggerUndo}

--- a/client/src/firehooks.ts
+++ b/client/src/firehooks.ts
@@ -85,6 +85,18 @@ export const useMyCourses = (): readonly FireCourse[] => {
     return allCourses.filter(course => myCourseUsers.some(courseUser => courseUser.courseId === course.courseId));
 };
 
+const courseTagQuery = (courseId: string) => firestore.collection('tags').where('courseId', '==', courseId);
+export const useCourseTags = (courseId: string): { readonly [tagId: string]: FireTag } => {
+    const tagsList = useQuery<FireTag>(courseId, courseTagQuery, 'tagId');
+    const tags: { [tagId: string]: FireTag } = {};
+
+    tagsList.forEach(tag => {
+        tags[tag.tagId] = tag;
+    });
+
+    return tags;
+};
+
 // Primatives
 // Look up a doc in Firebase by ID
 export const useCourseUser = (courseUserId: string | undefined) =>


### PR DESCRIPTION
This diff is built upon the foundation of the previous two hookification diffs.

With prefetch, we can reduce the number of IO from O(n) to O(1), and remove a lot of unnecessary caching logic in SessionQuestion component!

### Notes <!-- Optional -->
<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Database schema change (anything that changes Postgres)
- [ ] I updated existing types in `/src/components/types/`
- [ ] Other change that could cause problems (Detailed in notes)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My changes requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
- [x] I tested affected functionality
- [x] I resolved any merge conflicts
- [x] My PR is ready for review
