### PR TITLE
Merge users and courseUsers collection

### DIFF
--- a/client/src/components/includes/CalendarView.tsx
+++ b/client/src/components/includes/CalendarView.tsx
@@ -13,14 +13,14 @@ type Props = {
     session?: FireSession;
     sessionCallback: (sessionId: string) => void;
     course?: FireCourse;
-    courseUser?: FireCourseUser;
+    user?: FireUser;
 };
 
 const getQuery = (courseId: string) => firestore.collection('sessions').where('courseId', '==', courseId);
 
 const ONE_DAY = 24 /* hours */ * 60 /* minutes */ * 60 /* seconds */ * 1000 /* millis */;
 
-export default ({ session, sessionCallback, course, courseUser }: Props) => {
+export default ({ session, sessionCallback, course, user }: Props) => {
     const [selectedDateEpoch, setSelectedDate] = React.useState(new Date().setHours(0, 0, 0, 0));
     const selectedDate = new Date(selectedDateEpoch);
 
@@ -36,7 +36,7 @@ export default ({ session, sessionCallback, course, courseUser }: Props) => {
         <aside className="CalendarView">
             <CalendarHeader
                 currentCourseCode={(course && course.code) || 'Loading'}
-                role={(courseUser && courseUser.role)}
+                role={(user && course && (user.roles[course.courseId] || 'student'))}
             />
             <CalendarDaySelect callback={setSelectedDate} />
             {course ?

--- a/client/src/components/includes/SessionView.tsx
+++ b/client/src/components/includes/SessionView.tsx
@@ -16,7 +16,6 @@ type Props = {
     backCallback: Function;
     joinCallback: Function;
     user: FireUser;
-    courseUser: FireCourseUser;
 };
 
 type UndoState = {
@@ -33,7 +32,7 @@ type AbsentState = {
 };
 
 const SessionViewInHooks = (
-    { course, session, questions, isDesktop, backCallback, joinCallback, user, courseUser }: Props
+    { course, session, questions, isDesktop, backCallback, joinCallback, user }: Props
 ) => {
     const tags = useCourseTags(course.courseId);
     const [
@@ -154,7 +153,7 @@ const SessionViewInHooks = (
             {isDesktop &&
                 <TopBar
                     user={user}
-                    role={courseUser.role}
+                    role={user.roles[course.courseId] || 'student'}
                     context="session"
                     courseId={course.courseId}
                 />
@@ -187,7 +186,7 @@ const SessionViewInHooks = (
             }
             {/* FUTURE_TODO - Just pass in the session and not a bunch of bools */}
             <SessionQuestionsContainer
-                isTA={courseUser.role !== 'student'}
+                isTA={user.roles[course.courseId] !== undefined}
                 questions={questions.filter(q => q.status === 'unresolved' || q.status === 'assigned')}
                 tags={tags}
                 handleJoinClick={joinCallback}

--- a/client/src/components/pages/CourseEditView.tsx
+++ b/client/src/components/pages/CourseEditView.tsx
@@ -1,15 +1,14 @@
 import * as React from 'react';
 import CourseSelection from '../includes/CourseSelection';
 import { Loader } from 'semantic-ui-react';
-import { useMyUser, useAllCourses, useOptionalMyCourseUsers } from '../../firehooks';
+import { useMyUser, useAllCourses } from '../../firehooks';
 
 export default () => {
     const user = useMyUser();
     const allCourses = useAllCourses();
-    const myCourseUsers = useOptionalMyCourseUsers();
-    if (user === undefined || allCourses.length === 0 || myCourseUsers === null) {
+    if (user === undefined || allCourses.length === 0) {
         // Clearly not all data have been loaded.
         return <Loader active={true} content="Loading" />;
     }
-    return <CourseSelection user={user} allCourses={allCourses} myCourseUsers={myCourseUsers} isEdit />;
+    return <CourseSelection user={user} allCourses={allCourses} isEdit />;
 };

--- a/client/src/components/pages/CourseSelectionView.tsx
+++ b/client/src/components/pages/CourseSelectionView.tsx
@@ -1,15 +1,14 @@
 import * as React from 'react';
 import CourseSelection from '../includes/CourseSelection';
 import { Loader } from 'semantic-ui-react';
-import { useMyUser, useAllCourses, useOptionalMyCourseUsers } from '../../firehooks';
+import { useMyUser, useAllCourses } from '../../firehooks';
 
 export default () => {
     const user = useMyUser();
     const allCourses = useAllCourses();
-    const myCourseUsers = useOptionalMyCourseUsers();
-    if (user === undefined || allCourses.length === 0 || myCourseUsers === null) {
+    if (user === undefined || allCourses.length === 0) {
         // Clearly not all data have been loaded.
         return <Loader active={true} content="Loading" />;
     }
-    return <CourseSelection user={user} allCourses={allCourses} myCourseUsers={myCourseUsers} isEdit={false} />;
+    return <CourseSelection user={user} allCourses={allCourses} isEdit={false} />;
 };

--- a/client/src/components/pages/SplitView.tsx
+++ b/client/src/components/pages/SplitView.tsx
@@ -6,7 +6,7 @@ import SessionView from '../includes/SessionView';
 import CalendarView from '../includes/CalendarView';
 import AddQuestion from '../includes/AddQuestion';
 
-import { useCourse, useSession, useMyCourseUser, useMyUser, useQuery } from '../../firehooks';
+import { useCourse, useSession, useMyUser, useQuery } from '../../firehooks';
 
 import TopBar from '../includes/TopBar';
 import { Loader } from 'semantic-ui-react';
@@ -31,7 +31,7 @@ const useWindowWidth = () => {
     return width;
 };
 
-const getQuestionsQuery = (sessionId: string) => 
+const getQuestionsQuery = (sessionId: string) =>
 {return firestore.collection('questions')
     //Which belong to the current session
     .where('sessionId', '==', sessionId)
@@ -58,7 +58,6 @@ const SplitView = (props: {
             : props.match.params.sessionId ? 'session' : 'calendar'
     );
 
-    const courseUser = useMyCourseUser(props.match.params.courseId);
     const user = useMyUser();
     const course = useCourse(props.match.params.courseId);
     const session = useSession(props.match.params.sessionId);
@@ -105,15 +104,14 @@ const SplitView = (props: {
             {(width > MOBILE_BREAKPOINT || activeView === 'calendar') &&
                 <CalendarView
                     course={course}
-                    courseUser={courseUser}
+                    user={user}
                     session={session}
                     sessionCallback={handleSessionClick}
                 />
             }{(width > MOBILE_BREAKPOINT || activeView !== 'calendar') &&
-                (session && course && user && courseUser ?
+                (session && course && user ?
                     <SessionView
                         course={course}
-                        courseUser={courseUser}
                         session={session}
                         questions={sessionQuestions}
                         user={user}
@@ -124,7 +122,7 @@ const SplitView = (props: {
                     : <section className="StudentSessionView">
                         <TopBar
                             user={user}
-                            role={courseUser ? courseUser.role : 'student'}
+                            role={(user && course && user.roles[course.courseId]) || 'student'}
                             context="student"
                             courseId={props.match.params.courseId}
                         />

--- a/client/src/components/types/fireData.d.ts
+++ b/client/src/components/types/fireData.d.ts
@@ -27,6 +27,7 @@ interface FireSessionSeries {
     sessionSeriesId: string;
 }
 
+/** @see FireUser for the enrollment invariant. */
 interface FireCourse {
     code: string;
     endDate: FireTimestamp;
@@ -42,15 +43,20 @@ interface FireCourse {
     year: string;
 }
 
+type PrivilegedFireCourseRole = 'professor' | 'ta';
 type FireCourseRole = 'professor' | 'ta' | 'student';
 
-interface FireCourseUser {
-    courseId: string;
-    userId: string;
-    role: FireCourseRole;
-    courseUserId: string;
-}
-
+/**
+ * Invariant for fire user and course enrollment:
+ *
+ * 1. Ids of all related courses of a user appear in the field `courses`.
+ * 2. For each course id above
+ *    - If the user's role is TA or professor, it will appear in the roles map.
+ *    - Otherwise, it will not appear in the roles map. (i.e. `role == 'student'` will never appear!)
+ * 3. The `roles` field are in sync with `FireCourse`'s `professors` and `tas` field
+ *
+ * @see FireCourse
+ */
 interface FireUser {
     createdAt: FireTimestamp;
     firstName: string;
@@ -59,6 +65,8 @@ interface FireUser {
     lastActivityAt: FireTimestamp;
     userId: string;
     email: string;
+    courses: readonly string[];
+    roles: { readonly [courseId: string]: PrivilegedFireCourseRole | undefined };
 }
 
 interface FireQuestion {


### PR DESCRIPTION
### Rationale

To improve performance of the questions container, this diff is a must: we should be able to prefetch a list of all course users along with user information in one request. Thus, `users` and `courseUsers` collection must be merged.

### Implementation

The implementation is constrained by several facts:

- Enforcibility of security rules
- Efficiency of query

Due to some weird constraint of firebase security rules, it's not possible to store the role and course enrollment together. Therefore, I have to split it to `courses` and `roles` field. If we store the `student` field, it's impossible to enforce the rule that only professsor can edit role. Therefore, I made the role == `student` implicit. I documented all the invaraints in `fireData.d.ts`.

### Notes <!-- Optional -->
<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes
<!-- Put an `x` in all the boxes that apply: -->
- [x] Database schema change (anything that changes Postgres)
- [x] I updated existing types in `/src/components/types/`
- [x] Other change that could cause problems (Detailed in notes)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My changes requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
- [x] I tested affected functionality
- [x] I resolved any merge conflicts
- [x] My PR is ready for review
