### PR TITLE
Optimize questions information loading

### DIFF
--- a/client/src/components/includes/ProfessorRolesTable.tsx
+++ b/client/src/components/includes/ProfessorRolesTable.tsx
@@ -4,7 +4,7 @@ import { Dropdown, Table } from 'semantic-ui-react';
 import * as _ from 'lodash';
 
 import { firestore } from '../../firebase';
-import { useCourse, useUsersInCourse } from '../../firehooks';
+import { useCourse, useCourseUsers } from '../../firehooks';
 
 const getUserRoleUpdate = (
     user: FireUser,
@@ -137,7 +137,7 @@ export default ({ courseId }: { courseId: string }) => {
     const [column, setColumn] = useState<columnT>('email');
     const course = useCourse(courseId);
 
-    const courseUsers: readonly EnrichedFireUser[] = useUsersInCourse(courseId)
+    const courseUsers: readonly EnrichedFireUser[] = useCourseUsers(courseId)
         .map(user => ({ ...user, role: user.roles[courseId] || 'student' }));
 
     const sortedCourseUsers: readonly EnrichedFireUser[] = (() => {

--- a/client/src/components/includes/SessionQuestionsContainer.tsx
+++ b/client/src/components/includes/SessionQuestionsContainer.tsx
@@ -8,6 +8,7 @@ const SHOW_FEEDBACK_QUEUE = 4;
 type Props = {
     readonly isTA: boolean;
     readonly questions: readonly FireQuestion[];
+    readonly users: { readonly [userId: string]: FireUser };
     readonly tags: { readonly [tagId: string]: FireTag };
     readonly myUserId: string;
     readonly handleJoinClick: Function;
@@ -104,6 +105,7 @@ const SessionQuestionsContainer = (props: Props) => {
                     <SessionQuestion
                         key={myQuestion[0].questionId}
                         question={myQuestion[0]}
+                        users={props.users}
                         tags={props.tags}
                         index={questions.indexOf(myQuestion[0])}
                         isTA={props.isTA}
@@ -120,6 +122,7 @@ const SessionQuestionsContainer = (props: Props) => {
                     <SessionQuestion
                         key={question.questionId}
                         question={question}
+                        users={props.users}
                         tags={props.tags}
                         index={i}
                         isTA={props.isTA}

--- a/client/src/components/includes/SessionView.tsx
+++ b/client/src/components/includes/SessionView.tsx
@@ -5,7 +5,7 @@ import SessionInformationHeader from '../includes/SessionInformationHeader';
 import SessionQuestionsContainer from '../includes/SessionQuestionsContainer';
 
 import { Icon } from 'semantic-ui-react';
-import { useCourseTags } from '../../firehooks';
+import { useCourseTags, useCourseUsersMap } from '../../firehooks';
 // import SessionAlertModal from './SessionAlertModal';
 
 type Props = {
@@ -35,6 +35,7 @@ const SessionViewInHooks = (
     { course, session, questions, isDesktop, backCallback, joinCallback, user }: Props
 ) => {
     const tags = useCourseTags(course.courseId);
+    const users = useCourseUsersMap(course.courseId);
     const [
         { undoAction, undoName, undoQuestionId, timeoutId },
         setUndoState
@@ -188,6 +189,7 @@ const SessionViewInHooks = (
             <SessionQuestionsContainer
                 isTA={user.roles[course.courseId] !== undefined}
                 questions={questions.filter(q => q.status === 'unresolved' || q.status === 'assigned')}
+                users={users}
                 tags={tags}
                 handleJoinClick={joinCallback}
                 myUserId={user.userId}

--- a/client/src/firehooks.ts
+++ b/client/src/firehooks.ts
@@ -85,9 +85,19 @@ export const useCourseTags = (courseId: string): { readonly [tagId: string]: Fir
 const courseUserQuery = (courseId: string) => (
     firestore.collection('users').where('courses', 'array-contains', courseId)
 );
-export const useUsersInCourse = (courseId: string): readonly FireUser[] => (
+export const useCourseUsers = (courseId: string): readonly FireUser[] => (
     useQuery<FireUser>(courseId, courseUserQuery, 'userId')
 );
+export const useCourseUsersMap = (courseId: string): { readonly [userId: string]: FireUser } => {
+    const courseUsers = useCourseUsers(courseId);
+    const map: { [userId: string]: FireUser } = {};
+
+    courseUsers.forEach(user => {
+        map[user.userId] = user;
+    });
+
+    return map;
+};
 
 // Primatives
 // Look up a doc in Firebase by ID


### PR DESCRIPTION
With the help of last diff, we are finally able to prefetch users information to avoid O(n) IO for client side join! Now our most IO intensive page achieves optimal IO efficiency!

### Notes <!-- Optional -->
<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Database schema change (anything that changes Postgres)
- [ ] I updated existing types in `/src/components/types/`
- [ ] Other change that could cause problems (Detailed in notes)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My changes requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
- [x] I tested affected functionality
- [x] I resolved any merge conflicts
- [x] My PR is ready for review
