### PR TITLE
Unbreak `createUseParamaterizedSingletonObservableHook`

### DIFF
--- a/client/src/utilities/singleton-observable-hook.ts
+++ b/client/src/utilities/singleton-observable-hook.ts
@@ -68,5 +68,13 @@ export const createUseParamaterizedSingletonObservableHook = <T>(
     observerCreator: (parameter: string) => SingletonObservable<T>
 ): ((parameter: string) => T) => {
     const manager = new ParamaterizedSingletonObservableManager(observerCreator);
-    return (parameter: string) => createUseSingletonObservableHook(manager.get(parameter))();
+    return (parameter: string) => {
+        const singletonObservable = manager.get(parameter);
+        const [value, setValue] = useState(singletonObservable.get());
+        useEffect(() => {
+            const subscription = singletonObservable.subscribe(latest => setValue(latest));
+            return () => subscription.unsubscribe();
+        }, [singletonObservable]);
+        return value;
+    };
 };


### PR DESCRIPTION
Put `singletonObservable` into useEffect dependency to fix caching issue

### Notes <!-- Optional -->
<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Database schema change (anything that changes Postgres)
- [ ] I updated existing types in `/src/components/types/`
- [ ] Other change that could cause problems (Detailed in notes)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My changes requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
- [x] I tested affected functionality
- [x] I resolved any merge conflicts
- [x] My PR is ready for review
