### PR TITLE
Unbreak ahead count computation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ node_modules
 !.github/
 !.eslintrc.json
 !.firebaserc
+!.editorconfig
 
 npm-debug.log*
 yarn-debug.log*

--- a/client/.editorconfig
+++ b/client/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+# editorconfig-tools is unable to ignore longs strings or urls
+max_line_length = 120

--- a/client/src/components/includes/AddQuestion.tsx
+++ b/client/src/components/includes/AddQuestion.tsx
@@ -124,7 +124,7 @@ class AddQuestion extends React.Component {
     public addQuestion = () => {
         if (auth.currentUser != null && this.state.selectedPrimary != null &&
             this.state.selectedSecondary != null) {
-            firestore.collection('questions').add({
+            const newQuestion: Omit<FireQuestion, 'questionId'> = {
                 askerId: auth.currentUser.uid,
                 answererId: '',
                 content: this.state.question,
@@ -133,10 +133,9 @@ class AddQuestion extends React.Component {
                 status: 'unresolved',
                 timeEntered: firebase.firestore.Timestamp.now(),
                 primaryTag: this.state.selectedPrimary.tagId,
-                secondaryTag: this.state.selectedSecondary.tagId,
-                endTime: this.props.session.endTime.seconds,
-                resolved: false
-            });
+                secondaryTag: this.state.selectedSecondary.tagId
+            };
+            firestore.collection('questions').add(newQuestion);
             this.setState({ redirect: true });
         }
     };

--- a/client/src/components/includes/CalendarSessionCard.tsx
+++ b/client/src/components/includes/CalendarSessionCard.tsx
@@ -2,6 +2,10 @@ import * as React from 'react';
 import Moment from 'react-moment';
 import chevron from '../../media/chevron.svg';
 import { useSessionQuestions, useSessionTANames } from '../../firehooks';
+import {
+    filterAndpartitionQuestions,
+    computeNumberAheadFromFilterAndpartitionQuestions
+} from '../../utilities/questions';
 
 const CalendarSessionCard = (props: {
     user: FireUser;
@@ -17,14 +21,8 @@ const CalendarSessionCard = (props: {
     const session = props.session;
     const questions: FireQuestion[] = useSessionQuestions(session.sessionId);
 
-    const unresolvedQuestions = questions.filter(question => !question.resolved);
-    const userQuestions = unresolvedQuestions.filter(question => question.askerId === props.user.userId);
-
-    const numAhead = userQuestions.length === 0
-        ? unresolvedQuestions.length
-        : unresolvedQuestions.filter(
-            question => question.timeEntered.toDate() <= userQuestions[0].timeEntered.toDate()
-        ).length - 1;
+    const [unresolvedQuestions, userQuestions] = filterAndpartitionQuestions(questions, props.user.userId);
+    const numAhead = computeNumberAheadFromFilterAndpartitionQuestions(unresolvedQuestions, userQuestions);
 
     const includeBookmark = userQuestions.length > 0;
 

--- a/client/src/components/includes/SessionInformationHeader.tsx
+++ b/client/src/components/includes/SessionInformationHeader.tsx
@@ -4,6 +4,7 @@ import { Icon } from 'semantic-ui-react';
 
 import people from '../../media/people.svg';
 import { useSessionQuestions, useSessionTAs } from '../../firehooks';
+import { computeNumberAhead } from '../../utilities/questions';
 
 type Props = {
     session: FireSession;
@@ -15,17 +16,7 @@ type Props = {
 
 const SessionInformationHeader = ({ session, course, callback, myUserId, isDesktop }: Props) => {
     const tas = useSessionTAs(session);
-
-    const questions: FireQuestion[] = useSessionQuestions(session.sessionId);
-
-    const unresolvedQuestions = questions.filter(question => !question.resolved);
-    const userQuestions = unresolvedQuestions.filter(question => question.askerId === myUserId);
-
-    const numAhead = userQuestions.length === 0
-        ? unresolvedQuestions.length
-        : unresolvedQuestions.filter(
-            question => question.timeEntered.toDate() <= userQuestions[0].timeEntered.toDate()
-        ).length - 1;
+    const numAhead = computeNumberAhead(useSessionQuestions(session.sessionId), myUserId || '');
 
     if (isDesktop) {
         return (

--- a/client/src/components/includes/SessionQuestion.tsx
+++ b/client/src/components/includes/SessionQuestion.tsx
@@ -128,9 +128,7 @@ class SessionQuestion extends React.Component<Props, State> {
     //This function produces a no show
     studentNoShow = (event: React.MouseEvent<HTMLElement>) => {
         firestore.doc(`questions/${this.props.question.questionId}`).update({
-            status: 'no-show',
-            //This question has been "resolved" and will not show up again
-            resolved: true
+            status: 'no-show'
         });
     };
 
@@ -138,9 +136,7 @@ class SessionQuestion extends React.Component<Props, State> {
     questionDone = (event: React.MouseEvent<HTMLElement>) => {
         firestore.doc(`questions/${this.props.question.questionId}`).update({
             status: 'resolved',
-            timeAddressed: firebase.firestore.Timestamp.now(),
-            //This question has been "resolved" and will not show up again
-            resolved: true
+            timeAddressed: firebase.firestore.Timestamp.now()
         });
     };
 

--- a/client/src/components/pages/SplitView.tsx
+++ b/client/src/components/pages/SplitView.tsx
@@ -10,6 +10,7 @@ import { useCourse, useSession, useMyUser, useSessionQuestions } from '../../fir
 
 import TopBar from '../includes/TopBar';
 import { Loader } from 'semantic-ui-react';
+import { filterUnresolvedQuestions } from '../../utilities/questions';
 
 // Also update in the main LESS file
 const MOBILE_BREAKPOINT = 920;
@@ -49,8 +50,7 @@ const SplitView = (props: {
     const user = useMyUser();
     const course = useCourse(props.match.params.courseId);
     const session = useSession(props.match.params.sessionId);
-    const sessionQuestions = useSessionQuestions(props.match.params.sessionId || '')
-        .filter(question => !question.resolved)
+    const sessionQuestions = filterUnresolvedQuestions(useSessionQuestions(props.match.params.sessionId || ''))
         .filter((_, index) => index < NUM_QUESTIONS_SHOWN);
     const width = useWindowWidth();
 

--- a/client/src/components/types/fireData.d.ts
+++ b/client/src/components/types/fireData.d.ts
@@ -76,8 +76,7 @@ interface FireQuestion {
     location: string;
     sessionId: string;
     status: 'assigned' | 'resolved' | 'retracted' | 'unresolved' | 'no-show';
-    resolved: boolean;
-    timeAddressed: FireTimestamp;
+    timeAddressed?: FireTimestamp;
     timeEntered: FireTimestamp;
     primaryTag: string;
     secondaryTag: string;

--- a/client/src/utilities/questions.ts
+++ b/client/src/utilities/questions.ts
@@ -1,0 +1,33 @@
+export const filterUnresolvedQuestions = (
+    allQuestions: readonly FireQuestion[]
+): readonly FireQuestion[] =>
+    allQuestions.filter(({ status }) => status === 'assigned' || status === 'unresolved');
+
+export const filterAndpartitionQuestions = (
+    allQuestions: readonly FireQuestion[],
+    userId: string
+): readonly [readonly FireQuestion[], readonly FireQuestion[]] => {
+    const unresolvedQuestions = filterUnresolvedQuestions(allQuestions);
+    const userQuestions = unresolvedQuestions.filter(question => question.askerId === userId);
+
+    return [unresolvedQuestions, userQuestions];
+};
+
+export const computeNumberAheadFromFilterAndpartitionQuestions = (
+    unresolvedQuestions: readonly FireQuestion[],
+    userQuestions: readonly FireQuestion[]
+): number => {
+    if (userQuestions.length === 0) {
+        return unresolvedQuestions.length;
+    }
+    return (
+        unresolvedQuestions.filter(
+            question => question.timeEntered.toDate() <= userQuestions[0].timeEntered.toDate()
+        ).length - 1
+    );
+};
+
+export const computeNumberAhead = (allQuestions: readonly FireQuestion[], userId: string): number =>
+    computeNumberAheadFromFilterAndpartitionQuestions(
+        ...filterAndpartitionQuestions(allQuestions, userId)
+    );


### PR DESCRIPTION
The value is calculated incorrectly because it uses the field `resolved`, which turned out to be unreliable. Instead, we should delete this field, and derive whether the question has been resolved from the field `status`.

### Notes <!-- Optional -->
<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes
<!-- Put an `x` in all the boxes that apply: -->
- [x] Database schema change (anything that changes Postgres)
- [x] I updated existing types in `/src/components/types/`
- [ ] Other change that could cause problems (Detailed in notes)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My changes requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
- [x] I tested affected functionality
- [x] I resolved any merge conflicts
- [x] My PR is ready for review
