### PR TITLE
Let TA add comments to student question

### DIFF
--- a/client/src/components/includes/SessionQuestion.tsx
+++ b/client/src/components/includes/SessionQuestion.tsx
@@ -56,7 +56,7 @@ type State = {
     undoName?: string;
 };
 
-//We no longer support dynamic updating of asker, answer, tags etc
+const FEATURE_TA_COMMENT_ENABLE_FLAG = localStorage.getItem('FEATURE_TA_COMMENT_ENABLE_FLAG') === 'true';
 
 class SessionQuestion extends React.Component<Props, State> {
     state: State;
@@ -138,6 +138,15 @@ class SessionQuestion extends React.Component<Props, State> {
             status: 'resolved',
             timeAddressed: firebase.firestore.Timestamp.now()
         });
+    };
+
+    questionComment = () => {
+        const taComment = prompt('Your comment', this.props.question.taComment);
+        if (taComment == null) {
+            return;
+        }
+        const update: Partial<FireQuestion> = { taComment: taComment };
+        firestore.doc(`questions/${this.props.question.questionId}`).update(update);
     };
 
     _onClick = (event: React.MouseEvent<HTMLElement>, updateQuestion: Function, status: string) => {
@@ -252,6 +261,9 @@ class SessionQuestion extends React.Component<Props, State> {
                     </div>
                     {(this.props.isTA || includeBookmark || this.props.includeRemove) &&
                         <p className={'Question' + studentCSS}>{question.content}</p>}
+                    {question.taComment && (
+                        <p className={'Question' + studentCSS}>TA Comment: {question.taComment}</p>
+                    )}
                 </div>
                 <div className="BottomBar">
                     {this.props.isTA && <span className="Spacer" />}
@@ -300,6 +312,11 @@ class SessionQuestion extends React.Component<Props, State> {
                                     >
                                         Done
                                     </p>
+                                    {FEATURE_TA_COMMENT_ENABLE_FLAG && (
+                                        <p className="Done" onClick={this.questionComment}>
+                                            Edit Comment
+                                        </p>
+                                    )}
                                     <p
                                         className="DotMenu"
                                     // onClick={() => this.setDotMenu(!this.state.showDotMenu)}

--- a/client/src/components/types/fireData.d.ts
+++ b/client/src/components/types/fireData.d.ts
@@ -73,6 +73,7 @@ interface FireQuestion {
     askerId: string;
     answererId: string;
     content: string;
+    taComment?: string;
     location: string;
     sessionId: string;
     status: 'assigned' | 'resolved' | 'retracted' | 'unresolved' | 'no-show';


### PR DESCRIPTION
During office hour today, Scott mentions that we might want a virtual whiteboard.

Implementing one is hard, but provide link to one is easy: we add an optional field to question called `taComment`. TA can edit this field, and it will be presented to the students. We can implement notification for this in this way in the future:

```typescript
useEffect(() => {
  if (cachedOldComment !== newComment && isStudent) {
    fireNotification(...);
  }
}, [cachedOldComment, newComment, isStudent]);
```

Right now the GUI does not look good, so it's gates behind a flag. You must enable it by manually running `localStorage.setItem('FEATURE_TA_COMMENT_ENABLE_FLAG', 'true')` in your console.

### Notes <!-- Optional -->

Student:
<img width="1674" alt="student" src="https://user-images.githubusercontent.com/4290500/77368517-bf177780-6d32-11ea-91a2-906c4e1de9c5.png">
TA:
<img width="1675" alt="ta" src="https://user-images.githubusercontent.com/4290500/77368525-c0e13b00-6d32-11ea-9d46-e3dd90fbdd78.png">


This should not be merged until we got PM and designer approval.

### Breaking Changes
<!-- Put an `x` in all the boxes that apply: -->
- [x] Database schema change (anything that changes Postgres)
- [x] I updated existing types in `/src/components/types/`
- [ ] Other change that could cause problems (Detailed in notes)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My changes requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
- [x] I tested affected functionality
- [x] I resolved any merge conflicts
- [x] My PR is ready for review
