### PR TITLE
Scott/show professors course in home fix

### DIFF
--- a/src/components/includes/CourseSelection.tsx
+++ b/src/components/includes/CourseSelection.tsx
@@ -121,7 +121,9 @@ function CourseSelection({ user, isEdit, allCourses }: Props): React.ReactElemen
                         </div>
                     </div>
                     <div className="CourseCards">
-                        {allCourses.filter(course => selectedCourseIds.includes(course.courseId) || isEdit)
+                        {allCourses.filter(course => selectedCourseIds.includes(course.courseId) ||
+                            currentlyEnrolledCourseIds.has(course.courseId)
+                            || isEdit)
                             .map((course) => {
                                 const role = currentlyEnrolledCourseIds.has(course.courseId)
                                     ? (user.roles[course.courseId] || 'student')


### PR DESCRIPTION
### Summary <!-- Required -->
Allow professors to see their own courses on the Home page.

<!-- Provide a general summary of your changes in the Title above -->
Added " || currentlyEnrolledCourseIds.has(course.courseId)" to allow courses that user is "enrolled" in but has not selected (courses where user is a professor)

<!-- Add your summary here -->

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->
View the Home screen if you're a professor of a course. Select all other courses and try again. Deselect all courses and try again.

<!-- Briefly describe how you test you changes. -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
