### PR TITLE
Scott/course selection cancel fix

### DIFF
--- a/src/components/includes/CourseSelection.tsx
+++ b/src/components/includes/CourseSelection.tsx
@@ -30,6 +30,7 @@ function CourseSelection({ user, isEdit, allCourses }: Props): React.ReactElemen
             ({ courseId }) => currentlyEnrolledCourseIds.has(courseId) && user.roles[courseId] === undefined
         )
     );
+
     const [selectedCourseIds, setSelectedCourseIds] = React.useState<string[]>([]);
 
     const coursesToEnroll: string[] = [];
@@ -74,14 +75,6 @@ function CourseSelection({ user, isEdit, allCourses }: Props): React.ReactElemen
         ));
     };
 
-    const onSwitch = () => {
-        if (isEdit) {
-            history.push('/home');
-        } else {
-            history.push('/edit');
-        }
-    };
-
     const onSubmit = () => {
         const newCourseSet = new Set(currentlyEnrolledCourseIds);
         coursesToEnroll.forEach(courseId => newCourseSet.add(courseId));
@@ -92,6 +85,14 @@ function CourseSelection({ user, isEdit, allCourses }: Props): React.ReactElemen
             history.push('/home');
             setIsWritingChanges(false);
         });
+    };
+
+    const onCancel = () => {
+        // don't add newly-selected courses... add back the newly-deselected courses
+        setSelectedCourses([...(selectedCourses.filter(course => !coursesToEnroll.includes(course.courseId))),
+        ...allCourses.filter(course => coursesToUnenroll.includes(course.courseId))]);
+
+        history.push('/home');
     };
 
     const selectedCoursesString = selectedCourses.length === 0
@@ -151,9 +152,9 @@ function CourseSelection({ user, isEdit, allCourses }: Props): React.ReactElemen
                     {isEdit && selectedCoursesString}
                 </div>
                 <div className="buttons">
-                    {isNormalEditingMode && (
-                        <button className="switch" onClick={onSwitch}>
-                            {isEdit ? 'Home' : 'Edit'}
+                    {!isEdit && (
+                        <button className="switch" onClick={() => { history.push('/edit') }}>
+                            Edit
                         </button>
                     )}
                     {isEdit && (
@@ -163,7 +164,7 @@ function CourseSelection({ user, isEdit, allCourses }: Props): React.ReactElemen
                         </button>
                     )}
                     {isEdit && isNormalEditingMode && (
-                        <button className="cancel" onClick={() => setSelectedCourses([])}>
+                        <button className={'cancel'} onClick={onCancel}>
                             Cancel
                         </button>
                     )}

--- a/src/components/includes/CourseSelection.tsx
+++ b/src/components/includes/CourseSelection.tsx
@@ -89,8 +89,10 @@ function CourseSelection({ user, isEdit, allCourses }: Props): React.ReactElemen
 
     const onCancel = () => {
         // don't add newly-selected courses... add back the newly-deselected courses
-        setSelectedCourses([...(selectedCourses.filter(course => !coursesToEnroll.includes(course.courseId))),
-        ...allCourses.filter(course => coursesToUnenroll.includes(course.courseId))]);
+        setSelectedCourses([
+            ...(selectedCourses.filter(course => !coursesToEnroll.includes(course.courseId))),
+            ...allCourses.filter(course => coursesToUnenroll.includes(course.courseId))
+        ]);
 
         history.push('/home');
     };
@@ -153,7 +155,7 @@ function CourseSelection({ user, isEdit, allCourses }: Props): React.ReactElemen
                 </div>
                 <div className="buttons">
                     {!isEdit && (
-                        <button className="switch" onClick={() => { history.push('/edit') }}>
+                        <button className="switch" onClick={() => { history.push('/edit'); }}>
                             Edit
                         </button>
                     )}


### PR DESCRIPTION
…home

### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
#### Behavior Changes
* cancel button now restores previously-selected courses and redirects to home
* home button is hidden in edit mode since you can just click cancel

#### Implementation Changes
* add onCancel method
* delete onSwitch method since it is no longer used in home/edit button

<!-- Add your summary here -->

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->
From home page, click "Edit." Select a course that is not selected, and deselect a course that is selected. Hit cancel. You should be returned to the homepages with no changes before. Repeat this by selecting "Edit courses" from splitview.

<!-- Briefly describe how you test you changes. -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
