### PR TITLE
[security] Avoid blanket users table read

### DIFF
--- a/src/components/includes/SessionView.tsx
+++ b/src/components/includes/SessionView.tsx
@@ -34,8 +34,9 @@ type AbsentState = {
 const SessionViewInHooks = (
     { course, session, questions, isDesktop, backCallback, joinCallback, user }: Props
 ) => {
+    const isTa = user.roles[course.courseId] !== undefined;
     const tags = useCourseTags(course.courseId);
-    const users = useCourseUsersMap(course.courseId);
+    const users = useCourseUsersMap(course.courseId, isTa);
     const [
         { undoAction, undoName, undoQuestionId, timeoutId },
         setUndoState
@@ -183,7 +184,7 @@ const SessionViewInHooks = (
             }
             {/* FUTURE_TODO - Just pass in the session and not a bunch of bools */}
             <SessionQuestionsContainer
-                isTA={user.roles[course.courseId] !== undefined}
+                isTA={isTa}
                 questions={questions.filter(q => q.status === 'unresolved' || q.status === 'assigned')}
                 users={users}
                 tags={tags}

--- a/src/components/pages/ProfessorPeopleView.tsx
+++ b/src/components/pages/ProfessorPeopleView.tsx
@@ -24,7 +24,7 @@ const ProfessorPeopleView = (props: RouteComponentProps<{ courseId: string }>) =
 
     const user = useMyUser();
     const course = useCourse(courseId);
-    const courseUsers = useCourseUsersMap(courseId);
+    const courseUsers = useCourseUsersMap(courseId, true);
 
     const [sessions, setSessions] = useState<FireSession[]>([]);
     const [questions, setQuestions] = useState<FireQuestion[][]>([]);


### PR DESCRIPTION
### Summary

Previously, we use on a client-side join between users and questions regardless whether the join is necessary. (The join in unnecessary for students since user information is never displayed to them.) This diff avoids such join for students.

Note on security rules:
It's not correct to simply ban all users table read by students. Following exceptions have to be added:
- user can read their own stuff
- professor, ta, admin can read everything
- student can read professors and ta's info (for displaying TA profile picture)

### Test Plan

Use a student account. Try log `users` after the line (see diff)

```ts
const users = useCourseUsersMap(course.courseId, isTa);
```

You will find the map is always empty.

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
