### PR TITLE
Fix contactText centering css bug on Safari

### DIFF
--- a/src/styles/login/LoginView.less
+++ b/src/styles/login/LoginView.less
@@ -32,6 +32,7 @@
         font-weight: bold;
         position: absolute;
         bottom: 30px;
+        left: calc(50% - 125px);
     }
 
     &.contact {


### PR DESCRIPTION
### Summary <!-- Required -->

Fix #300 by explicitly calculating left offset

### Test Plan <!-- Required -->

<img width="1299" alt="Screen Shot 2020-04-09 at 00 07 53" src="https://user-images.githubusercontent.com/4290500/78857016-3bc67900-79f6-11ea-924f-305f0ad1f817.png">
<img width="826" alt="Screen Shot 2020-04-09 at 00 07 56" src="https://user-images.githubusercontent.com/4290500/78857025-42ed8700-79f6-11ea-80a9-bb4548dc1cad.png">
