### PR TITLE
Fix arrow-down incorrect rotation css

### DIFF
--- a/src/styles/calendar/CalendarHeader.less
+++ b/src/styles/calendar/CalendarHeader.less
@@ -49,8 +49,7 @@
         }
 
         .RotateDown {
-            rotate: (90deg);
-            -webkit-transform: rotate(90deg); // Temporary fix for icon placeholder
+            transform: rotate(90deg); // Temporary fix for icon placeholder
             cursor: pointer;
             filter: brightness(0) invert(1);
             padding: 0 10px;


### PR DESCRIPTION
### Summary <!-- Required -->

Fix #294.

### Test Plan <!-- Required -->

Chrome:
<img width="390" alt="Screen Shot 2020-04-09 at 00 31 37" src="https://user-images.githubusercontent.com/4290500/78858253-dc6a6800-79f9-11ea-9469-3aeff766ef4d.png">
Firefox:
<img width="391" alt="Screen Shot 2020-04-09 at 00 32 04" src="https://user-images.githubusercontent.com/4290500/78858257-deccc200-79f9-11ea-9141-89d4d776a8c6.png">
Safari:
<img width="390" alt="Screen Shot 2020-04-09 at 00 32 38" src="https://user-images.githubusercontent.com/4290500/78858259-e0968580-79f9-11ea-8120-5b12c12d9e88.png">