### PR TITLE
Fix staging build config

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build-less": "cd src/styles && less-watch-compiler ./ ./ index.less",
     "build-less:prod": "lessc --clean-css src/styles/index.less src/styles/index.min.css",
     "deploy": "yarn build-less:prod && yarn build",
-    "deploy:staging": "REACT_APP_IS_STAGING=true yarn build-less:prod && yarn build",
+    "deploy:staging": "yarn build-less:prod && REACT_APP_IS_STAGING=true yarn build",
     "eject": "react-scripts eject",
     "start": "concurrently \"yarn run build-less\" \"react-scripts start\"",
     "s": "yarn start",


### PR DESCRIPTION
### Summary <!-- Required -->

Mode the env-var set code close to `yarn build`, so it's actually applied during build.

### Test Plan <!-- Required -->

Build it locally by `yarn deploy:staging`. Serve it. Log out. Log in. You will see the login url is qmi-test, which is the staging url