### PR TITLE
Unbreak student view for their own questions

### DIFF
--- a/src/components/includes/SessionQuestion.tsx
+++ b/src/components/includes/SessionQuestion.tsx
@@ -197,11 +197,11 @@ class SessionQuestion extends React.Component<Props, State> {
 
         const asker = this.props.users[question.askerId];
         const answerer = question.answererId
-            ? undefined : this.props.users[question.answererId];
+            ? this.props.users[question.answererId] : undefined;
         const primaryTag = this.props.question.primaryTag
-            ? undefined : this.props.tags[this.props.question.primaryTag];
+            ? this.props.tags[this.props.question.primaryTag] : undefined;
         const secondaryTag = this.props.question.secondaryTag
-            ? undefined : this.props.tags[this.props.question.secondaryTag];
+            ? this.props.tags[this.props.question.secondaryTag] : undefined;
 
         return (
             <div className="QueueQuestions">

--- a/src/components/includes/SessionQuestionsContainer.tsx
+++ b/src/components/includes/SessionQuestionsContainer.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import SessionQuestion from './SessionQuestion';
 import { Icon } from 'semantic-ui-react';
 import moment from 'moment';
+import { useDoc } from '../../firehooks';
 
 const SHOW_FEEDBACK_QUEUE = 4;
 //Maximum number of questions to be shown to user
@@ -20,6 +21,40 @@ type Props = {
     readonly isPast: boolean;
     readonly openingTime: Date;
     readonly haveAnotherQuestion: boolean;
+};
+
+type StudentMyQuestionProps = {
+    readonly questionId: string;
+    readonly tags: { readonly [tagId: string]: FireTag };
+    readonly index: number;
+    readonly triggerUndo: Function;
+    readonly isPast: boolean;
+    readonly myUserId: string;
+};
+
+const StudentMyQuestion = ({ questionId, tags, index, triggerUndo, isPast, myUserId }: StudentMyQuestionProps) => {
+    const studentQuestion = useDoc<FireQuestion>('questions', questionId, 'questionId');
+    if (studentQuestion == null) {
+        return <div />;
+    }
+
+    return (
+        <div className="User">
+            <p className="QuestionHeader">My Question</p>
+            <SessionQuestion
+                key={questionId}
+                question={studentQuestion}
+                users={{}}
+                tags={tags}
+                index={index}
+                isTA={false}
+                includeRemove={true}
+                triggerUndo={triggerUndo}
+                isPast={isPast}
+                myUserId={myUserId}
+            />
+        </div>
+    );
 };
 
 const SessionQuestionsContainer = (props: Props) => {
@@ -107,21 +142,14 @@ const SessionQuestionsContainer = (props: Props) => {
                 </div>
             }
             {shownQuestions && myQuestion && myQuestion.length > 0 &&
-                <div className="User">
-                    <p className="QuestionHeader">My Question</p>
-                    <SessionQuestion
-                        key={myQuestion[0].questionId}
-                        question={myQuestion[0]}
-                        users={props.users}
-                        tags={props.tags}
-                        index={allQuestions.indexOf(myQuestion[0])}
-                        isTA={props.isTA}
-                        includeRemove={true}
-                        triggerUndo={props.triggerUndo}
-                        isPast={props.isPast}
-                        myUserId={props.myUserId}
-                    />
-                </div>
+                <StudentMyQuestion
+                    questionId={myQuestion[0].questionId}
+                    tags={props.tags}
+                    index={allQuestions.indexOf(myQuestion[0])}
+                    triggerUndo={props.triggerUndo}
+                    isPast={props.isPast}
+                    myUserId={props.myUserId}
+                />
             }
             {shownQuestions && shownQuestions.length > 0 && props.isTA &&
                 shownQuestions.map((question, i: number) => (


### PR DESCRIPTION
### Summary

The latest privacy fix splits questions and questionSlots. This left over a bug that students cannot see their own questions now. This diff fetches the full question when the question belongs to the student.

It also fixes a bug where tags are not shown.

### Test Plan

Join as student, post your question, now you can see your content.

<img width="1227" alt="Screen Shot 2020-04-12 at 14 43 54" src="https://user-images.githubusercontent.com/4290500/79077000-0ce92500-7ccc-11ea-9495-347cad8581c3.png">


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
