### PR TITLE
Fix borken Firebase 'in' query with more

### DIFF
--- a/src/components/includes/SessionView.tsx
+++ b/src/components/includes/SessionView.tsx
@@ -58,7 +58,8 @@ const SessionView = (
             return;
         }
         
-        if ((user.roles[course.courseId] === 'professor' || user.roles[course.courseId] === 'ta') && questions.length > 0) {
+        if ((user.roles[course.courseId] === 'professor' ||
+        user.roles[course.courseId] === 'ta') && questions.length > 0) {
             addNotification({
                 title: 'A new question has been added!',
                 message: 'Check the queue.',

--- a/src/firebasefunctions.ts
+++ b/src/firebasefunctions.ts
@@ -1,5 +1,6 @@
 import { firestore, auth } from 'firebase/app';
 import { datePlus, normalizeDateToDateStart, normalizeDateToWeekStart } from './utilities/date';
+import { blockArray } from './firehooks';
 
 /* Basic Functions */
 
@@ -218,34 +219,45 @@ const importProfessorsOrTAs = async (
     db: firebase.firestore.Firestore,
     course: FireCourse,
     role: 'professor' | 'ta',
-    emailList: readonly string[]
+    emailListTotal: readonly string[]
 ): Promise<void> => {
-    const taUserDocuments = await db.collection('users').where('email', 'in', emailList).get();
-    const missingSet = new Set(emailList);
+    const missingSet = new Set(emailListTotal);
     const batch = db.batch();
     const updatedUsers: FireUser[] = [];
-    taUserDocuments.forEach((document) => {
-        const existingUser = { userId: document.id, ...document.data() } as FireUser;
-        const { email } = existingUser;
-        const roleUpdate = getUserRoleUpdate(existingUser, course.courseId, role);
-        batch.update(db.collection('users').doc(existingUser.userId), roleUpdate);
-        updatedUsers.push(existingUser);
-        missingSet.delete(email);
-    });
-    batch.update(
-        db.collection('courses').doc(course.courseId),
-        getCourseRoleUpdates(
-            course,
-            updatedUsers.map((user) => [user.userId, role] as const)
-        )
-    );
-    await batch.commit();
-    const message =
+    
+    const emailBlocks = blockArray(emailListTotal, 10);
+    
+    Promise.all(emailBlocks.map(emailList => {
+        return db.collection('users').where('email', 'in', emailList).get().then(taUserDocuments => {
+            taUserDocuments.forEach((document: firestore.QueryDocumentSnapshot<firestore.DocumentData>) => {
+                const existingUser = { userId: document.id, ...document.data() } as FireUser;
+                const { email } = existingUser;
+                const roleUpdate = getUserRoleUpdate(existingUser, course.courseId, role);
+                batch.update(db.collection('users').doc(existingUser.userId), roleUpdate);
+                updatedUsers.push(existingUser);
+                missingSet.delete(email);
+            });
+            batch.update(
+                db.collection('courses').doc(course.courseId),
+                getCourseRoleUpdates(
+                    course,
+                    updatedUsers.map((user) => [user.userId, role] as const)
+                )
+            );
+        });
+            
+    })).then(() => {
+        batch.commit();
+    }).then(() => {
+        const message =
         'Successfully\n' +
         `updated: [${updatedUsers.map((user) => user.email).join(', ')}];\n` +
         `[${Array.from(missingSet).join(', ')}] do not exist in our system yet.`;
-    // eslint-disable-next-line no-alert
-    alert(message);
+        // eslint-disable-next-line no-alert
+        alert(message);
+    });
+
+    
 };
 
 const addOrRemoveFromRoleIdList = (

--- a/src/firebasefunctions.ts
+++ b/src/firebasefunctions.ts
@@ -231,7 +231,7 @@ const importProfessorsOrTAs = async (
         return db.collection('users').where('email', 'in', emailList).get().then(taUserDocuments => {
             const updatedUsersThisBlock: FireUser[] = [];
 
-            taUserDocuments.forEach((document: firestore.QueryDocumentSnapshot<firestore.DocumentData>) => {
+            taUserDocuments.forEach((document) => {
                 const existingUser = { userId: document.id, ...document.data() } as FireUser;
                 const roleUpdate = getUserRoleUpdate(existingUser, course.courseId, role);
                 batch.update(db.collection('users').doc(existingUser.userId), roleUpdate);

--- a/src/firehooks.ts
+++ b/src/firehooks.ts
@@ -157,16 +157,6 @@ export const useCourseUsersMap = (courseId: string, canReadUsers: boolean): Fire
 
 const dummyProfessorOrTAList = ['DUMMY'];
 
-const courseProfessorOrTaQuery = (professorsOrTas: readonly string[]) => {
-    return firestore
-        .collection('users')
-        .where(
-            firebase.firestore.FieldPath.documentId(),
-            'in',
-            professorsOrTas.length === 0 ? dummyProfessorOrTAList : professorsOrTas
-        )
-};
-
 const courseProfessorOrTaBatchQuery = (professorsOrTas: readonly string[]) => {
     const blocks = blockArray(professorsOrTas.length === 0 ? dummyProfessorOrTAList : professorsOrTas, 10);
 

--- a/src/firehooks.ts
+++ b/src/firehooks.ts
@@ -67,11 +67,11 @@ export const useBatchQueryWithLoading = <T, P=string>(
                 // updates results as they come in. Triggers re-renders.
                 const subscription = results$.subscribe(results => {
                     partialResult = [...partialResult, ...results];
+                    setResult(partialResult);
                 })
                 return () => { subscription.unsubscribe(); };
             });
 
-            setResult(partialResult);
 
             return () => {
                 effects.forEach(unsubscription => unsubscription());
@@ -82,6 +82,7 @@ export const useBatchQueryWithLoading = <T, P=string>(
     );
     return result;
 };
+
 
 export const useQuery = <T, P=string>(
     queryParameter: P,
@@ -168,7 +169,7 @@ const courseProfessorOrTaBatchQuery = (professorsOrTas: readonly string[]) => {
     
 };
 
-const blockArray = <T>(arr: readonly T[], blockSize: number) => {
+export const blockArray = <T>(arr: readonly T[], blockSize: number) => {
     let result: T[][] = [];
     for (let i = 0; i < arr.length; i += blockSize) {
         result = [...result, arr.slice(i, Math.min(arr.length, i + blockSize))];


### PR DESCRIPTION
### Summary <!-- Required -->
##### Serious issue! Due to the limitations of Firebase's 'in' query, prod breaks when:
1) there are > 10 TAs in a course. Attempting to view the AdminView causes an error because loading TAs/profs uses ```useCourseProfessorMap``` and ```useCourseTAMap```, which break when they attempt to query > 10 TAs or > 10 professors in a course at once
2) a professor attempts to add ≥ 10 TAs at once in ProfessorRolesTable.
3) loading SessionView in a class with > 10 TAs. (Or > 10 professors. Which is unlikely).

<!-- Provide a general summary of your changes in the Title above -->
#### Fixes
Break up a single batched queries that involve 'in' into chunks of size 10, the maximum size limit that Firebase's 'in' query supports.

##### useBatchQueryWithLoading
Replaces calls to ```useQueryWithLoading``` in some cases. The only difference with ```useQueryWithLoading``` is that it takes in a function that generates multiple queries (these are the result of breaking up our intended query into multiple smaller queries). This fix allows AdminView to generate ```courseTAMap``` and ```courseProfessorMap``` in several batches.

Also added intermediate helper functions ```useBatchQuery``` to replace some ```useQuery``` calls and ```blockArray``` to break arrays into smaller-size chunks.

##### fixed import TA
```importProfessorsOrTAs``` now breaks the list of TAs to be imported into 10-size chunks that each are queried in parallel. Assuming that the update batch

#### Smallish problems
Drawback: the fix does not help in the case for too many professors. But a course needs 11+ professors in order to break it.



### Test Plan <!-- Required -->
All instances that use ```.where(..., 'in', ...)``` need to be tested.

#### Test Admin View's professors and TAs map
One of these is the function ```useCourseCourseProfessorOrTaMap```, which calls useBatchQueryWithLoading with a function that generates multiple queries. The only two times this is used so far is in AdminView, which needs to create a professors map and TAs map once the admin view is loaded. Successfully loading the Admin View when there there exists a class with ≥ 11 TAs without errors => the fix works.

#### Test Import TA functionality for > 10 users
Was tested by successfully promoting 11 'students' into 11 TAs for the TC 1001 class on qmi-test.firebaseapp.com

![Screen Shot 2020-04-24 at 12 07 19 AM](https://user-images.githubusercontent.com/18223523/80175341-533f5d80-85c3-11ea-963c-935650ef669f.png)
![Screen Shot 2020-04-24 at 12 07 42 AM](https://user-images.githubusercontent.com/18223523/80175343-533f5d80-85c3-11ea-9157-9d2e0ace3352.png)


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
