### PR TITLE
Clear OH info only for new sessions

### DIFF
--- a/src/components/includes/ProfessorOHInfo.tsx
+++ b/src/components/includes/ProfessorOHInfo.tsx
@@ -306,7 +306,7 @@ const ProfessorOHInfo = (props: {
                             updateNotification(stateNotification);
                         } else {
                             mutateSessionOrSeries();
-                            clearFields();
+                            (props.isNewOH && clearFields()); 
                             props.toggleEdit();
                         }
                     }}


### PR DESCRIPTION
### Summary <!-- Required -->
Fixes  #337

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->
* Tested with creating a new session
* Tested with updating an existing session and saving changes

### Notes <!-- Optional -->
- The issue was calling clearFields when saving changes to an existing session so that it cleared the pre-populated fields. clearFields should only be called when creating new sessions to clear out inputs.
- The TA selection dropdown does not completely clear out when using clearFields, which may be an issue with the dropdown component itself?

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
