### PR TITLE
Fix #350

### DIFF
--- a/src/components/includes/ProfessorTagInfo.tsx
+++ b/src/components/includes/ProfessorTagInfo.tsx
@@ -43,7 +43,8 @@ class ProfessorTagInfo extends React.Component<PropTypes, State> {
     }
 
     handleNameChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
-        this.setState((state) => ({ tag: { ...state.tag, name: event.target.value } }));
+        const name = event.currentTarget.value;
+        this.setState((state) => ({ tag: { ...state.tag, name } }));
     };
 
     handleNewTagTextChange = (event: React.ChangeEvent<HTMLInputElement>): void => {


### PR DESCRIPTION
### Summary

Use currentTarget since it's more reliable, and it solves the problem.

### Test Plan

Type a letter. It no longer crashes.

### Notes

https://github.com/facebook/react/issues/5733