### PR TITLE
Fix linter errors

### DIFF
--- a/src/components/includes/AddQuestion.tsx
+++ b/src/components/includes/AddQuestion.tsx
@@ -78,7 +78,7 @@ class AddQuestion extends React.Component<Props, State> {
     };
 
     public handlePrimarySelected = (tag: FireTag | undefined): void => {
-        this.setState(this.state.stage <= 10
+        this.setState(({ stage }) => stage <= 10
             ? { stage: 20, selectedPrimary: tag }
             : { stage: 10, selectedPrimary: undefined, selectedSecondary: undefined }
         );
@@ -98,24 +98,24 @@ class AddQuestion extends React.Component<Props, State> {
 
     public handleUpdateLocation = (event: React.ChangeEvent<HTMLTextAreaElement>): void => {
         const target = event.target as HTMLTextAreaElement;
-        let stage;
+        let stage: number;
         if (target.value.length > 0) {
             if (this.state.question.length > 0) {
                 stage = 50;
             } else { stage = 40; }
         } else { stage = 30; }
-        this.setState({
-            location: target.value.length <= LOCATION_CHAR_LIMIT ? target.value : this.state.location,
+        this.setState(({ location }) => ({
+            location: target.value.length <= LOCATION_CHAR_LIMIT ? target.value : location,
             stage
-        });
+        }));
     };
 
     public handleUpdateQuestion = (event: React.ChangeEvent<HTMLTextAreaElement>): void => {
         const target = event.target as HTMLTextAreaElement;
-        this.setState({
-            question: target.value.length <= this.props.course.charLimit ? target.value : this.state.question,
+        this.setState(({ question }) => ({
+            question: target.value.length <= this.props.course.charLimit ? target.value : question,
             stage: target.value.length > 0 ? 50 : 40
-        });
+        }));
     };
 
     public addQuestion = () => {

--- a/src/components/includes/Analytics.tsx
+++ b/src/components/includes/Analytics.tsx
@@ -10,27 +10,25 @@ interface AnalyticsProps {
     };
 }
 
-export class Analytics extends React.Component {
-    props!: AnalyticsProps;
+const sendPageChange = (pathname: string, search = '') => {
+    const page = pathname + search;
+    ReactGA.set({ page });
+    ReactGA.pageview(page);
+};
 
+export class Analytics extends React.Component<AnalyticsProps> {
     constructor(props: AnalyticsProps) {
         super(props);
         // Initial page load - only fired once
-        this.sendPageChange(props.location.pathname, props.location.search);
+        sendPageChange(props.location.pathname, props.location.search);
     }
 
     componentDidUpdate(prevProps: AnalyticsProps) {
         // When props change, check if the URL has changed or not
         if (this.props.location.pathname !== prevProps.location.pathname
             || this.props.location.search !== prevProps.location.search) {
-            this.sendPageChange(this.props.location.pathname, this.props.location.search);
+            sendPageChange(this.props.location.pathname, this.props.location.search);
         }
-    }
-
-    sendPageChange(pathname: string, search = '') {
-        const page = pathname + search;
-        ReactGA.set({ page });
-        ReactGA.pageview(page);
     }
 
     render() {

--- a/src/components/includes/CalendarDateItem.tsx
+++ b/src/components/includes/CalendarDateItem.tsx
@@ -15,10 +15,10 @@ class CalendarDateItem extends React.PureComponent<Props> {
 
     render() {
         return (
-            <div className={'menuDate' + (this.props.active ? ' active' : '')} onClick={this._onClick}>
+            <button type="button" className={'menuDate' + (this.props.active ? ' active' : '')} onClick={this._onClick}>
                 <div className="day">{this.props.day}</div>
                 <div className="date">{this.props.date}</div>
-            </div>
+            </button>
         );
     }
 }

--- a/src/components/includes/CalendarDaySelect.tsx
+++ b/src/components/includes/CalendarDaySelect.tsx
@@ -9,18 +9,13 @@ const dayList = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 const monthNames = ['January', 'February', 'March', 'April', 'May', 'June',
     'July', 'August', 'September', 'October', 'November', 'December'];
 
-class CalendarDaySelect extends React.Component {
+type Props = { callback: (time: number) => void };
+type State = { selectedWeekEpoch: number; active: number };
 
-    props!: {
-        callback: (time: number) => void;
-    };
+class CalendarDaySelect extends React.Component<Props, State> {
+    state: State;
 
-    state!: {
-        selectedWeekEpoch: number;
-        active: number;
-    };
-
-    constructor(props: {}) {
+    constructor(props: Props) {
         super(props);
         const week = new Date(); // now
         week.setHours(0, 0, 0, 0); // beginning of today (00:00:00.000)
@@ -56,9 +51,9 @@ class CalendarDaySelect extends React.Component {
             <div className="CalendarDaySelect">
                 <p className="month">{monthNames[now.getMonth()]}</p>
                 <div className="selector">
-                    <span className="LastWeek" onClick={() => this.incrementWeek(false)}>
+                    <button type="button" className="LastWeek" onClick={() => this.incrementWeek(false)}>
                         <img src={chevron} alt="Previous Week" className="flipped" />
-                    </span>
+                    </button>
                     {dayList.map((day, i) => <CalendarDateItem
                         key={i}
                         index={i}
@@ -67,9 +62,9 @@ class CalendarDaySelect extends React.Component {
                         active={i === this.state.active}
                         handleClick={this.handleDateClick}
                     />)}
-                    <span className="NextWeek" onClick={() => this.incrementWeek(true)}>
+                    <button type="button" className="NextWeek" onClick={() => this.incrementWeek(true)}>
                         <img src={chevron} alt="Next Week" />
-                    </span>
+                    </button>
                 </div>
             </div>
         );

--- a/src/components/includes/CalendarSessions.tsx
+++ b/src/components/includes/CalendarSessions.tsx
@@ -13,9 +13,11 @@ const CalendarSessions = ({ activeSession, user, course, sessions, callback }: {
     const labelSession = (session: FireSession, intervalMs: number) => {
         if (new Date(session.endTime.toDate()) < new Date()) {
             return 'Past';
-        } else if (new Date(session.startTime.toDate()) < new Date()) {
+        }
+        if (new Date(session.startTime.toDate()) < new Date()) {
             return 'Ongoing';
-        } else if (new Date(session.startTime.toDate()) < new Date(new Date().getTime() + intervalMs)) {
+        }
+        if (new Date(session.startTime.toDate()) < new Date(new Date().getTime() + intervalMs)) {
             return 'Open';
         }
 

--- a/src/components/includes/CalendarView.tsx
+++ b/src/components/includes/CalendarView.tsx
@@ -30,9 +30,9 @@ export default ({ session, sessionCallback, course, user }: Props) => {
     );
 
     const filteredSessions = sessions && sessions.filter(
-        session => {
-            const sessionStart = session.startTime.toDate();
-            const sessionEnd = session.endTime.toDate();
+        s => {
+            const sessionStart = s.startTime.toDate();
+            const sessionEnd = s.endTime.toDate();
             return hasOverlap(sessionStart, sessionEnd, selectedDate, selectedDateEnd);
         }
     );

--- a/src/components/includes/CalendarWeekSelect.tsx
+++ b/src/components/includes/CalendarWeekSelect.tsx
@@ -44,12 +44,12 @@ class CalendarWeekSelect extends React.Component<Props, State> {
     //     return weekText;
     // }
 
-    getMonth(epoch: number): string {
+    static getMonth(epoch: number): string {
         const now = new Date(epoch);
         return monthNames[now.getMonth()];
     }
 
-    getDay(epoch: number): number {
+    static getDay(epoch: number): number {
         const now = new Date(epoch);
         return now.getDate();
     }
@@ -89,16 +89,16 @@ class CalendarWeekSelect extends React.Component<Props, State> {
                 <div className="CurrentWeek">
                     <span className="Date">
                         <span className="Month">
-                            {this.getMonth(thisWeekEpoch)}
+                            {CalendarWeekSelect.getMonth(thisWeekEpoch)}
                         </span>
-                        {' ' + this.getDay(thisWeekEpoch)}
+                        {' ' + CalendarWeekSelect.getDay(thisWeekEpoch)}
                     </span>
                     -
                     <span className="Date">
                         <span className="Month">
-                            {this.getMonth(nextWeekEpoch)}
+                            {CalendarWeekSelect.getMonth(nextWeekEpoch)}
                         </span>
-                        {' ' + this.getDay(nextWeekEpoch)}
+                        {' ' + CalendarWeekSelect.getDay(nextWeekEpoch)}
                     </span>
                 </div>
                 <span className="NextWeek" onClick={() => this.handleWeekClick(false)}>

--- a/src/components/includes/Popup.tsx
+++ b/src/components/includes/Popup.tsx
@@ -1,43 +1,39 @@
-/* eslint-disable @typescript-eslint/indent */
-
 import * as React from 'react';
 import { Icon } from 'semantic-ui-react';
 import QMeLogo from '../../media/QLogo2.svg';
 
 type Props = {
-  show: boolean;
-  topTitle: string;
-  description: string;
-  buttonLabel: string;
-  link: string;
-  hideFunction: () => void;
+    show: boolean;
+    topTitle: string;
+    description: string;
+    buttonLabel: string;
+    link: string;
+    hideFunction: () => void;
 };
 
-class Popup extends React.Component<Props> {
-  render() {
-    const isShown = this.props.show ? ' feedback' : '';
+const Popup = ({ show, topTitle, description, buttonLabel, link, hideFunction }: Props) => {
+    const isShown = show ? ' feedback' : '';
 
     return (
-      <>
-        <section className={'topPanel' + isShown}>
-          <button type="button" className="closeIcon" onClick={() => this.props.hideFunction()}>
-            <Icon name="x" />
-          </button>
-          <img src={QMeLogo} className="QMeLogo" alt="Queue Me In Logo" />
-          <h2>{this.props.topTitle}</h2>
-          <p>{this.props.description}</p>
-        </section>
-        <section className={'bottomPanel' + isShown}>
-          <a
-            className="feedbackButton"
-            href={this.props.link}
-          >
-            {this.props.buttonLabel}
-          </a>
-        </section>
-      </>
+        <>
+            <section className={'topPanel' + isShown}>
+                <button type="button" className="closeIcon" onClick={() => hideFunction()}>
+                    <Icon name="x" />
+                </button>
+                <img src={QMeLogo} className="QMeLogo" alt="Queue Me In Logo" />
+                <h2>{topTitle}</h2>
+                <p>{description}</p>
+            </section>
+            <section className={'bottomPanel' + isShown}>
+                <a
+                    className="feedbackButton"
+                    href={link}
+                >
+                    {buttonLabel}
+                </a>
+            </section>
+        </>
     );
-  }
-}
+};
 
 export default Popup;

--- a/src/components/includes/ProfessorSettings.tsx
+++ b/src/components/includes/ProfessorSettings.tsx
@@ -69,9 +69,9 @@ class ProfessorSettings extends React.Component<Props, State> {
                         <button
                             type="button"
                             className="decrement"
-                            onClick={() => this.setState({
-                                charLimit: Math.max(this.state.charLimit - CHAR_INCREMENT, 0)
-                            })}
+                            onClick={() => this.setState(({ charLimit }) => ({
+                                charLimit: Math.max(charLimit - CHAR_INCREMENT, 0)
+                            }))}
                             disabled={this.state.charLimit <= 0}
                         >
                             <Icon name="minus" />
@@ -84,9 +84,9 @@ class ProfessorSettings extends React.Component<Props, State> {
                         <button
                             type="button"
                             className="increment"
-                            onClick={() => this.setState({
-                                charLimit: Math.min(this.state.charLimit + CHAR_INCREMENT, 999)
-                            })}
+                            onClick={() => this.setState(({ charLimit }) => ({
+                                charLimit: Math.min(charLimit + CHAR_INCREMENT, 999)
+                            }))}
                         >
                             <Icon name="plus" />
                         </button>

--- a/src/components/includes/ProfessorSidebar.tsx
+++ b/src/components/includes/ProfessorSidebar.tsx
@@ -8,22 +8,20 @@ type Props = {
     selected: number;
 }
 
-class ProfessorSidebar extends React.Component<Props> {
+const ProfessorSidebar = ({ courseId, code, selected }: Props) => {
+    const selectedArray: string[] = ['', '', '', ''];
+    selectedArray[selected] = 'selected';
 
-    render() {
-        const selectedArray: string[] = ['', '', '', ''];
-        selectedArray[this.props.selected] = 'selected';
-
-        return (
-            <div className="ProfessorSidebar">
-                <div className="nav">
-                    <div className="header">
-                        <span>
-                            {this.props.code}
-                            {/* <Icon name="dropdown" /> */}
-                        </span>
-                    </div>
-                    {/* <div className="manage">
+    return (
+        <div className="ProfessorSidebar">
+            <div className="nav">
+                <div className="header">
+                    <span>
+                        {code}
+                        {/* <Icon name="dropdown" /> */}
+                    </span>
+                </div>
+                {/* <div className="manage">
                         <button className={selectedArray[0]}>
                             <Icon name="users" />
                             People
@@ -34,45 +32,44 @@ class ProfessorSidebar extends React.Component<Props> {
                             </button>
                     </div>
                     <div className="divider" /> */}
-                    <div className="actions">
-                        <Link to={'/professor/course/' + this.props.courseId}>
-                            <button type="button" className={selectedArray[0]}>
-                                <Icon name="setting" />
+                <div className="actions">
+                    <Link to={'/professor/course/' + courseId}>
+                        <button type="button" className={selectedArray[0]}>
+                            <Icon name="setting" />
                                 Manage Hours
-                            </button>
-                        </Link>
-                        <Link to={'/professor-tags/course/' + this.props.courseId}>
-                            <button type="button" className={selectedArray[1]}>
-                                <Icon name="settings" />
+                        </button>
+                    </Link>
+                    <Link to={'/professor-tags/course/' + courseId}>
+                        <button type="button" className={selectedArray[1]}>
+                            <Icon name="settings" />
                                 Manage Tags
-                            </button>
-                        </Link>
-                        <Link to={'/professor-dashboard/course/' + this.props.courseId}>
-                            <button type="button" className={selectedArray[2]}>
-                                <Icon name="line graph" />
+                        </button>
+                    </Link>
+                    <Link to={'/professor-dashboard/course/' + courseId}>
+                        <button type="button" className={selectedArray[2]}>
+                            <Icon name="line graph" />
                                 Dashboard
-                            </button>
-                        </Link>
-                        <Link to={'/professor-people/course/' + this.props.courseId}>
-                            <button type="button" className={selectedArray[3]}>
-                                <Icon name="users" />
+                        </button>
+                    </Link>
+                    <Link to={'/professor-people/course/' + courseId}>
+                        <button type="button" className={selectedArray[3]}>
+                            <Icon name="users" />
                                 People
-                            </button>
-                        </Link>
-                        <Link to={'/professor-roles/course/' + this.props.courseId}>
-                            <button type="button" className={selectedArray[4]}>
-                                <Icon name="id card outline" />
+                        </button>
+                    </Link>
+                    <Link to={'/professor-roles/course/' + courseId}>
+                        <button type="button" className={selectedArray[4]}>
+                            <Icon name="id card outline" />
                                 Manage Roles
-                            </button>
-                        </Link>
-                    </div>
+                        </button>
+                    </Link>
                 </div>
-                {/* <svg className="logo" width="100" height="100">
+            </div>
+            {/* <svg className="logo" width="100" height="100">
                     <circle cx="50" cy="50" r="10" fill="#7ab7fe" />
                 </svg> */}
-            </div>
-        );
-    }
+        </div>
+    );
 }
 
 export default ProfessorSidebar;

--- a/src/components/includes/ProfessorTagInfo.tsx
+++ b/src/components/includes/ProfessorTagInfo.tsx
@@ -101,10 +101,7 @@ class ProfessorTagInfo extends React.Component<PropTypes, State> {
         });
 
         // converts reference parentTag to the string format stored in state
-        this.setState(function (prevState) {
-            prevState.tag.tagId = parentTag.id;
-            return { tag: prevState.tag };
-        });
+        this.setState((prevState) => ({ tag: { ...prevState.tag, tagId: parentTag.id } }));
 
         // below is essentially add new child a bunch of times
         this.state.newTags.forEach(tagText => {

--- a/src/components/includes/ProfessorTagsDelete.tsx
+++ b/src/components/includes/ProfessorTagsDelete.tsx
@@ -7,38 +7,36 @@ type Props = {
     numQuestions: number;
 };
 
-class ProfessorTagsDelete extends React.Component<Props> {
-    render() {
-        return (
-            <>
-                <div className="ProfessorTagsDelete">
-                    <div className="question">
-                        Are you sure you want to delete this tag?
+const ProfessorTagsDelete = ({ assignmentName, isActivated, numQuestions }: Props) => {
+    return (
+        <>
+            <div className="ProfessorTagsDelete">
+                <div className="question">
+                    Are you sure you want to delete this tag?
+                </div>
+                <div className="info">
+                    <div className="assignmentName">
+                        {assignmentName}
                     </div>
-                    <div className="info">
-                        <div className="assignmentName">
-                            {this.props.assignmentName}
-                        </div>
-                        <div>
-                            <span>
-                                <Checkbox
-                                    label="Activated?"
-                                    checked={this.props.isActivated}
-                                    readOnly={true}
-                                />
-                            </span>
-                            <span>
-                                Questions: {this.props.numQuestions}
-                            </span>
-                        </div>
+                    <div>
+                        <span>
+                            <Checkbox
+                                label="Activated?"
+                                checked={isActivated}
+                                readOnly={true}
+                            />
+                        </span>
+                        <span>
+                            Questions: {numQuestions}
+                        </span>
                     </div>
                 </div>
-                <button type="button" className="Delete">
-                    Delete
-                </button>
-            </>
-        );
-    }
+            </div>
+            <button type="button" className="Delete">
+                Delete
+            </button>
+        </>
+    );
 }
 
 export default ProfessorTagsDelete;

--- a/src/components/includes/QuestionsBarChart.tsx
+++ b/src/components/includes/QuestionsBarChart.tsx
@@ -47,9 +47,8 @@ class QuestionsBarChart extends React.Component<Props> {
                     </div>
                 </div>
             );
-        } else {
-            return <div>N/A</div>;
         }
+        return <div>N/A</div>;
     }
 
     render() {

--- a/src/components/includes/SessionQuestionsContainer.tsx
+++ b/src/components/includes/SessionQuestionsContainer.tsx
@@ -5,12 +5,12 @@ import SessionQuestion from './SessionQuestion';
 import { firestore } from '../../firebase';
 
 const SHOW_FEEDBACK_QUEUE = 4;
-//Maximum number of questions to be shown to user
+// Maximum number of questions to be shown to user
 const NUM_QUESTIONS_SHOWN = 20;
 
 type Props = {
     readonly isTA: boolean;
-    //Note that these questions are sorted by time asked
+    // Note that these questions are sorted by time asked
     readonly questions: readonly FireQuestion[];
     readonly users: { readonly [userId: string]: FireUser };
     readonly tags: { readonly [tagId: string]: FireTag };

--- a/src/components/includes/SessionView.tsx
+++ b/src/components/includes/SessionView.tsx
@@ -65,7 +65,7 @@ const SessionView = (
         if (newQuestions.size <= 0) {
             return;
         }
-        
+
         if ((user.roles[course.courseId] === 'professor' ||
         user.roles[course.courseId] === 'ta') && questions.length > 0) {
             addNotification({
@@ -136,16 +136,16 @@ const SessionView = (
     };
     */
 
-    const isOpen = (session: FireSession, interval: number): boolean => {
+    const isOpen = (s: FireSession, interval: number): boolean => {
         const intervalInMilliseconds = interval * 1000 * 60;
-        return session.startTime.toDate().getTime() - intervalInMilliseconds < new Date().getTime()
-            && session.endTime.toDate().getTime() > new Date().getTime();
+        return s.startTime.toDate().getTime() - intervalInMilliseconds < new Date().getTime()
+            && s.endTime.toDate().getTime() > new Date().getTime();
     };
 
-    const isPast = (session: FireSession): boolean => new Date() > new Date(session.endTime.toDate());
+    const isPast = (s: FireSession): boolean => new Date() > new Date(s.endTime.toDate());
 
-    const getOpeningTime = (session: FireSession, interval: number): Date => (
-        new Date(new Date(session.startTime.toDate()).getTime() - interval * 1000 * 60)
+    const getOpeningTime = (s: FireSession, interval: number): Date => (
+        new Date(new Date(s.startTime.toDate()).getTime() - interval * 1000 * 60)
     );
 
     let undoText = '';

--- a/src/components/includes/registerServiceWorker.ts
+++ b/src/components/includes/registerServiceWorker.ts
@@ -53,6 +53,7 @@ function registerValidSW(swUrl: string) {
   navigator.serviceWorker
     .register(swUrl)
     .then(registration => {
+      // eslint-disable-next-line no-param-reassign
       registration.onupdatefound = () => {
         const installingWorker = registration.installing;
         if (installingWorker) {

--- a/src/styles/calendar/CalendarDaySelect.scss
+++ b/src/styles/calendar/CalendarDaySelect.scss
@@ -23,6 +23,13 @@ $red: #f67d7d;
         .LastWeek,
         .NextWeek {
             cursor: pointer;
+            background-color: transparent;
+            border-color: transparent;
+        }
+
+        .LastWeek,
+        .NextWeek:focus {
+            outline: 0;
         }
     }
 }
@@ -35,10 +42,17 @@ $red: #f67d7d;
     width: 30px;
 }
 
+.menuDate:focus {
+    outline: 0;
+}
+
 .menuDate {
     cursor: pointer;
     height: 54px;
     width: 30px;
+    background-color: transparent;
+    border-color: transparent;
+    padding: 0;
 
     &.active {
         cursor: default;


### PR DESCRIPTION
### Summary

Fix some easy linter errors.

Some of the a11y fixes are tricky, since I have to restyle something. It appears to me that the original authors are just abusing the default style provided by span, div, without considering that we need to use `button` to convey the semantic meaning of button to make the website accessible.

### Test Plan

Less linter errors in CI. Changed styles are identical to the old ones.