### PR TITLE
Remove unnecessary type definition

### DIFF
--- a/types/react-web-notification/index.d.ts
+++ b/types/react-web-notification/index.d.ts
@@ -1,1 +1,0 @@
-declare module 'react-web-notification';


### PR DESCRIPTION
### Summary <!-- Required -->

This typedef is unnecessary since `react-web-notification` is already written in TS. 

### Test Plan <!-- Required -->

CI passes, which shows that this file is really redundant.