### PR TITLE
Add static script to force migration.

### DIFF
--- a/public/static/js/main.9cebe396.js
+++ b/public/static/js/main.9cebe396.js
@@ -1,0 +1,11 @@
+const result = navigator.serviceWorker.getRegistrations().then(function unregister(registrations) {
+    return Promise.all(registrations.map(registration => registration.unregister()));
+}).catch(err => {
+    // eslint-disable-next-line no-console
+    console.error(err);
+    window.location.reload();
+});
+
+if (result.finally) {
+    result.finally(() => { window.location.reload(); })
+}


### PR DESCRIPTION
### Summary <!-- Required -->

Our old instance of queueme.in didn't set its cache headers correctly so for some people index.html is permanently cached. To fix this, we're going to insert a script which will forcibly remove the service worker and reload the instance.

The script is harmless, unless you have an old install.

<!-- Provide a general summary of your changes in the Title above -->

<!-- Add your summary here -->

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->

Contact a team mate with a broken instance and ask them to reload the page.

<!-- Briefly describe how you test you changes. -->

### Notes <!-- Optional -->

This should be removed in a few weeks.

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
