### PR TITLE
WIP: [a11y] Make QueueMeIn tab-navigable and use aria.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-ga": "^2.5.3",
     "react-moment": "^0.8.2",
     "react-numeric-input": "^2.2.3",
+    "react-outside-click-handler": "^1.3.0",
     "react-push-notification": "^1.3.0",
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",
@@ -65,6 +66,7 @@
     "@types/react-dates": "^17.1.3",
     "@types/react-dom": "^16.9.4",
     "@types/react-numeric-input": "^2.2.3",
+    "@types/react-outside-click-handler": "^1.3.0",
     "@types/react-router": "^5.1.1",
     "@types/react-router-dom": "^5.1.0",
     "babel-preset-react-app-babel-7": "^4.0.2-0",
@@ -80,7 +82,7 @@
     "firebase-tools": "^7.13.1",
     "node-sass": "^4.13.1",
     "ts-mocha": "^8.0.0",
-    "typescript": "^3.7.3"
+    "typescript": "~3.8.3"
   },
   "browserslist": {
     "production": [

--- a/src/components/includes/AccessibleButton.tsx
+++ b/src/components/includes/AccessibleButton.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { onEnterOrSpace } from "../../utilities/a11y";
+
+const AccessibleButton: React.FC<{
+    onInteract: () => void;
+    className?: string;
+}> = ({onInteract, className = "", children}) => 
+    (<div
+        role="button"
+        className={className}
+        onClick={onInteract}
+        onKeyPress={onEnterOrSpace(onInteract)}
+        tabIndex={0}
+    >{children}</div>);
+
+export default AccessibleButton;

--- a/src/components/includes/AddQuestion.tsx
+++ b/src/components/includes/AddQuestion.tsx
@@ -5,6 +5,7 @@ import { Icon } from 'semantic-ui-react';
 import moment from 'moment';
 import firebase from 'firebase/app';
 
+import AccessibleButton from './AccessibleButton';
 import SelectedTags from './SelectedTags';
 import SessionAlertModal from './SessionAlertModal';
 
@@ -22,7 +23,6 @@ type Props = {
 type State = {
     location: string;
     question: string;
-    selectedTags: number[];
     stage: number;
     width: number;
     redirect: boolean;
@@ -46,7 +46,6 @@ class AddQuestion extends React.Component<Props, State> {
         question: '',
         stage: 10,
         width: window.innerWidth,
-        selectedTags: [],
         redirect: false,
         tags: []
     };
@@ -202,7 +201,8 @@ class AddQuestion extends React.Component<Props, State> {
         const { selectedPrimary, selectedSecondary } = this.state;
 
         return (
-            <div className="QuestionView" onKeyDown={(e) => this.handleKeyPressDown(e)} >
+            // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+            <div className="QuestionView" role="group" onKeyDown={(e) => this.handleKeyPressDown(e)} >
                 {(this.state.stage < 60 || this.state.width < this.props.mobileBreakpoint) &&
                     <div className="AddQuestion">
                         <div className="queueHeader">
@@ -315,9 +315,12 @@ class AddQuestion extends React.Component<Props, State> {
                             </div>
                             <div className="addButtonWrapper">
                                 {this.state.stage > 40 ?
-                                    <p className="AddButton active" onClick={() => this.handleJoinClick()} >
+                                    <AccessibleButton 
+                                        className="AddButton active"
+                                        onInteract={() => this.handleJoinClick()}
+                                    >
                                         Add My Question
-                                    </p>
+                                    </AccessibleButton>
                                     : <p className="AddButton"> Add My Question </p>
                                 }
                             </div>

--- a/src/components/includes/CalendarSessionCard.tsx
+++ b/src/components/includes/CalendarSessionCard.tsx
@@ -7,6 +7,8 @@ import {
     computeNumberAheadFromFilterAndpartitionQuestions
 } from '../../utilities/questions';
 
+import AccessibleButton from './AccessibleButton';
+
 const CalendarSessionCard = (props: {
     user: FireUser;
     course: FireCourse;
@@ -32,7 +34,7 @@ const CalendarSessionCard = (props: {
 
     const timeDesc = '';
     return (
-        <div className={(props.active && 'active') + ' CalendarSessionCard'} onClick={handleOnClick}>
+        <AccessibleButton className={(props.active && 'active') + ' CalendarSessionCard'} onInteract={handleOnClick}>
             {includeBookmark && <div className="Bookmark" />}
             <div className="TimeInfo">
                 <div className="StartTime">
@@ -79,7 +81,7 @@ const CalendarSessionCard = (props: {
             <div className="OpenButton">
                 <img src={chevron} alt="Open session dropdown" />
             </div>
-        </div>
+        </AccessibleButton>
     );
 };
 export default CalendarSessionCard;

--- a/src/components/includes/CalendarWeekSelect.tsx
+++ b/src/components/includes/CalendarWeekSelect.tsx
@@ -1,4 +1,7 @@
 import * as React from 'react';
+
+import AccessibleButton from './AccessibleButton';
+
 import chevron from '../../media/chevron.svg';
 
 const ONE_DAY = 24 /* hours */ * 60 /* minutes */ * 60 /* seconds */ * 1000 /* millis */;
@@ -58,15 +61,15 @@ class CalendarWeekSelect extends React.Component<Props, State> {
     // previousWeek = false means that the next week was clicked in the week selector
     handleWeekClick(previousWeek: boolean) {
         if (previousWeek) {
-            this.setState({
-                selectedWeekEpoch: this.state.selectedWeekEpoch -
+            this.setState((state) => ({
+                selectedWeekEpoch: state.selectedWeekEpoch -
                     7 /* days */ * 24 /* hours */ * 60 /* minutes */ * 60 /* seconds */ * 1000 /* millis */
-            });
+            }));
         } else {
-            this.setState({
-                selectedWeekEpoch: this.state.selectedWeekEpoch +
+            this.setState((state) => ({
+                selectedWeekEpoch: state.selectedWeekEpoch +
                     7 /* days */ * 24 /* hours */ * 60 /* minutes */ * 60 /* seconds */ * 1000 /* millis */
-            });
+            }));
         }
         if (this.props.handleClick !== undefined) {
             this.props.handleClick(previousWeek);
@@ -83,9 +86,9 @@ class CalendarWeekSelect extends React.Component<Props, State> {
 
         return (
             <div className="CalendarWeekSelect">
-                <span className="LastWeek" onClick={() => this.handleWeekClick(true)}>
+                <AccessibleButton className="LastWeek" onInteract={() => this.handleWeekClick(true)}>
                     <img src={chevron} alt="Previous Week" className="flipped" />
-                </span>
+                </AccessibleButton>
                 <div className="CurrentWeek">
                     <span className="Date">
                         <span className="Month">
@@ -101,9 +104,9 @@ class CalendarWeekSelect extends React.Component<Props, State> {
                         {' ' + CalendarWeekSelect.getDay(nextWeekEpoch)}
                     </span>
                 </div>
-                <span className="NextWeek" onClick={() => this.handleWeekClick(false)}>
+                <AccessibleButton className="NextWeek" onInteract={() => this.handleWeekClick(false)}>
                     <img src={chevron} alt="Next Week" />
-                </span>
+                </AccessibleButton>
             </div>
         );
     }

--- a/src/components/includes/CourseCard.tsx
+++ b/src/components/includes/CourseCard.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { useHistory } from 'react-router';
 import { Icon } from 'semantic-ui-react';
 
+import AccessibleButton from './AccessibleButton';
+
 type Props = {
     course: FireCourse;
     // If not provided, it means that the student is not enrolled in the class yet.
@@ -15,7 +17,7 @@ type Props = {
 const CourseCard = ({ course, role, onSelectCourse, editable, selected, inactive = false }: Props) => {
     const history = useHistory();
 
-    const selectCourse = () => {
+    const selectCourse = React.useCallback(() => {
         if (!editable) {
             if (!inactive) history.push('/course/' + course.courseId);
             return;
@@ -23,7 +25,7 @@ const CourseCard = ({ course, role, onSelectCourse, editable, selected, inactive
         if (role === undefined || role === 'student') {
             onSelectCourse(!selected);
         }
-    };
+    }, [editable, history, role, onSelectCourse, course.courseId, selected, inactive]);
 
     let roleString = '';
     if (role === 'ta') {
@@ -32,9 +34,9 @@ const CourseCard = ({ course, role, onSelectCourse, editable, selected, inactive
         roleString = 'PROF';
     }
     return (
-        <div
+        <AccessibleButton
             className={`CourseCard ${selected && editable ? 'selected' : ''} ${inactive ? 'inactive' : 'active'}`}
-            onClick={selectCourse}
+            onInteract={selectCourse}
         >
             <div className="courseText">
                 <div className="courseCode">
@@ -60,7 +62,7 @@ const CourseCard = ({ course, role, onSelectCourse, editable, selected, inactive
                     </div> :
                     <></>
             }
-        </div>
+        </AccessibleButton>
     );
 };
 

--- a/src/components/includes/DropDownEntry.tsx
+++ b/src/components/includes/DropDownEntry.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { onEnterOrSpace } from '../../utilities/a11y';
+
+const DropDownEntry: React.FC<{
+    onSelect: () => void;
+}> = ({ onSelect, children }) => {
+    return (<li>
+        <div
+            role="button" 
+            tabIndex={0}
+            onMouseDown={(event) => event.preventDefault()}
+            onKeyPress={onEnterOrSpace(onSelect)}
+            onClick={() => onSelect()}           
+        >
+            {children}
+        </div>
+    </li>);
+};
+
+export default DropDownEntry;

--- a/src/components/includes/ProfessorOHInfo.tsx
+++ b/src/components/includes/ProfessorOHInfo.tsx
@@ -275,8 +275,8 @@ const ProfessorOHInfo = (props: {
                     (ta, i) => {
                         // Filter dropdown by checking if TA has not been selected yet
                         // Include currently selected TA, or else dropdown can't prepopulate if option is missing
-                        const dropdownOptions = props.taOptions.filter(ta =>
-                            ta.value === taSelected[i].id || !taSelected.some(s => s.id === ta.value));
+                        const dropdownOptions = props.taOptions.filter(t =>
+                            t.value === taSelected[i].id || !taSelected.some(s => s.id === t.value));
 
                         return (
                             <div className={'AddTA ' + (i === 0 ? 'First' : 'Additional')} key={ta.id || i}>

--- a/src/components/includes/ProfessorTagInfo.tsx
+++ b/src/components/includes/ProfessorTagInfo.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { Icon } from 'semantic-ui-react';
 import { firestore } from '../../firebase';
 
+import AccessibleButton from './AccessibleButton';
+
 type PropTypes = {
     isNew: boolean;
     cancelCallback: Function;
@@ -190,19 +192,20 @@ class ProfessorTagInfo extends React.Component<PropTypes, State> {
                     </div>
                     <div className="Status InputSection">
                         <div className="InputHeader">Status</div>
-                        <div
+                        <AccessibleButton
                             className={'ActiveButton first ' + (this.state.tag.active ? 'Selected' : '')}
-                            onClick={() => this.handleActiveChange(true)}
+                            onInteract={() => this.handleActiveChange(true)}
                         >
                             Active
-                        </div>
-                        <div
+                        </AccessibleButton>
+                        <AccessibleButton
                             className={'ActiveButton ' + (this.state.tag.active ? '' : 'Selected')}
-                            onClick={() => this.handleActiveChange(false)}
+                            onInteract={() => this.handleActiveChange(false)}
                         >
                             Inactive
-                        </div>
+                        </AccessibleButton>
                     </div>
+                    { /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */ }
                     <div className="ChildTags InputSection" onKeyDown={(e) => this.handleEnterPress(e)}>
                         <div className="InputHeader">Tags</div>
                         {this.state.newTags
@@ -224,12 +227,12 @@ class ProfessorTagInfo extends React.Component<PropTypes, State> {
                             placeholder="Type to add a new tag..."
                             value={this.state.newTagText}
                         />
-                        <div
+                        <AccessibleButton
                             className={'InputChildTagEnter ' + (this.state.newTagText.length > 0 ? '' : 'disabled')}
-                            onClick={this.handleNewTagEnter}
+                            onInteract={this.handleNewTagEnter}
                         >
                             +
-                        </div>
+                        </AccessibleButton>
                     </div>
                 </div>
                 <div className="EditButtons">

--- a/src/components/includes/SelectedTags.tsx
+++ b/src/components/includes/SelectedTags.tsx
@@ -1,4 +1,7 @@
 import * as React from 'react';
+
+import AccessibleButton from './AccessibleButton';
+
 import Uncheck from '../../media/uncheck.svg';
 import Check from '../../media/check.svg';
 import YellowUncheck from '../../media/yellowUncheck.svg';
@@ -27,7 +30,7 @@ class SelectedTags extends React.PureComponent<Props> {
         return (
             <>
                 {this.props.select? 
-                    <div className="selectTag" onClick={this._onClick}>
+                    <AccessibleButton className="selectTag" onInteract={this._onClick}>
                         <div className="selectTagContents">
                             {this.props.isPrimary? (this.props.check?
                                 <img src={Check} alt="check"/>
@@ -38,16 +41,16 @@ class SelectedTags extends React.PureComponent<Props> {
                             }
                             {this.props.tag.name}
                         </div>
-                    </div>
-                    :<p
+                    </AccessibleButton>
+                    :<AccessibleButton
                         className={['tag',
                             this.props.tag.level === 1 ? 'primaryTag' : 'secondaryTag',
                             this.props.isDiscussion && 'discussion',
                             this.props.isSelected && 'selectedTag'].join(' ')}
-                        onClick={this._onClick}
+                        onInteract={this._onClick}
                     >
                         {this.props.tag.name}
-                    </p>
+                    </AccessibleButton>
                 }
             </>
         );

--- a/src/components/includes/SessionAlertModal.tsx
+++ b/src/components/includes/SessionAlertModal.tsx
@@ -5,6 +5,8 @@ import { Icon } from 'semantic-ui-react';
 import { SemanticICONS } from 'semantic-ui-react/dist/commonjs/generic';
 import { useSessionTANames } from '../../firehooks';
 
+import AccessibleButton from './AccessibleButton';
+
 type Props = {
     readonly header?: string;
     readonly icon?: SemanticICONS;
@@ -12,7 +14,7 @@ type Props = {
     readonly description: string;
     readonly course: FireCourse;
     readonly OHSession?: FireSession;
-    readonly buttons: string[];
+    readonly buttons: readonly string[];
     readonly cancelAction?: Function;
     readonly mainAction?: Function;
     readonly displayShade: boolean;
@@ -33,6 +35,8 @@ const SessionAlertModal = (
 
     const buttonsToRender = buttons.map((button, i) => (
         <button
+            // This is a static array so we can use the array index.
+            // eslint-disable-next-line react/no-array-index-key
             key={i}
             type="button"
             className={buttons.length - 1 === i ? 'last' : ''}
@@ -53,7 +57,7 @@ const SessionAlertModal = (
 
     return (
         <div className="SessionAlertModal">
-            <div className={'modalShadeAlert ' + shadeDisplay} onClick={() => cancel()} />
+            <AccessibleButton className={'modalShadeAlert ' + shadeDisplay} onInteract={() => cancel()} />
             <div className={'modalContent ' + shadeDisplay}>
                 <div className={'text ' + color}>
                     {header && <div className="title">{header}</div>}

--- a/src/components/includes/SessionInformationHeader.tsx
+++ b/src/components/includes/SessionInformationHeader.tsx
@@ -10,6 +10,8 @@ import closeZoom from '../../media/closeZoom.svg';
 import editZoomLink from '../../media/editZoomLink.svg';
 import { useSessionQuestions, useSessionTAs } from '../../firehooks';
 import { computeNumberAhead } from '../../utilities/questions';
+
+import AccessibleButton from './AccessibleButton';
 import JoinErrorMessage from './JoinErrorMessage';
 
 
@@ -272,10 +274,10 @@ const SessionInformationHeader = ({ session, course, callback, user, isDesktop, 
     return (
         <header className="SessionInformationHeader" >
             <div className="header">
-                <p className="BackButton" onClick={() => callback()}>
+                <AccessibleButton className="BackButton" onInteract={() => callback()}>
                     <i className="left" />
                     {course.code}
-                </p>
+                </AccessibleButton>
                 <div className="CourseInfo">
                     <div className="CourseDetails">
                         {'building' in session ? <span>

--- a/src/components/includes/SessionQuestion.tsx
+++ b/src/components/includes/SessionQuestion.tsx
@@ -7,7 +7,9 @@ import { useState } from "react";
 import Linkify from 'linkifyjs/react';
 import addNotification from 'react-push-notification';
 import { firestore } from '../../firebase';
+import AccessibleButton from './AccessibleButton';
 import SelectedTags from './SelectedTags';
+import { onEnterOrSpace } from '../../utilities/a11y';
 
 // TODO_ADD_SERVER_CHECK
 const LOCATION_CHAR_LIMIT = 40;
@@ -38,6 +40,10 @@ type State = {
     enableEditingComment: boolean;
     width: number;
 };
+
+function getDisplayText(index: number): string {
+    return (index + 1).toFixed(0);
+}
 
 class SessionQuestion extends React.Component<Props, State> {
     state: State;
@@ -85,17 +91,6 @@ class SessionQuestion extends React.Component<Props, State> {
                 // TODO(ewlsh): Handle this better, this notification library doesn't handle iOS
             }
         }
-    }
-
-    // Given an index from [1..n], converts it to text that is displayed on the
-    // question cards. 1 => "NOW", 2 => "2nd", 3 => "3rd", and so on.
-    getDisplayText(index: number): string {
-        index++;
-        // Disclaimer: none of us wrote this one-line magic :) It is borrowed
-        // from https://stackoverflow.com/revisions/39466341/5 return index +
-        // ['st', 'nd', 'rd'][((index + 90) % 100 - 10) % 10 - 1] || index +
-        // 'th';
-        return String(index);
     }
 
 
@@ -234,7 +229,7 @@ class SessionQuestion extends React.Component<Props, State> {
                     {!this.props.includeRemove && includeBookmark && <div className="Bookmark" />}
                     <div>
                         <p className={'Order ' + (question.status === 'assigned' ? 'assigned' : '')}>
-                            {question.status === 'assigned' ? '•••' : this.getDisplayText(this.props.index)}
+                            {question.status === 'assigned' ? '•••' : getDisplayText(this.props.index)}
                         </p>
                     </div>
                     {this.props.includeRemove && !['virtual', 'review'].includes(this.props.modality) &&
@@ -242,6 +237,9 @@ class SessionQuestion extends React.Component<Props, State> {
                             <Icon
                                 onClick={this.toggleLocationTooltip}
                                 name="map marker alternate"
+                                role="button"
+                                tabIndex={0}
+                                onKeyPress={onEnterOrSpace(this.toggleLocationTooltip)}
                             />
                             <div
                                 className="LocationTooltip"
@@ -351,34 +349,43 @@ class SessionQuestion extends React.Component<Props, State> {
                         <hr />
                         <div className="TAButtons">
                             {question.status === 'unresolved' &&
-                                <p className="Begin" onClick={this.assignQuestion}>
+                                <AccessibleButton className="Begin" onInteract={this.assignQuestion}>
                                     Assign to Me
-                                </p>
+                                </AccessibleButton>
                             }
                             {question.status === 'assigned' &&
                                 <>
-                                    <p className="Delete" onClick={this.studentNoShow}>No show</p>
-                                    <p className="Done" onClick={this.questionDone}>Done</p>
-                                    <p
+                                    <AccessibleButton
+                                        className="Delete"
+                                        onInteract={this.studentNoShow}
+                                    >
+                                        No show
+                                    </AccessibleButton>
+                                    <AccessibleButton 
+                                        className="Done"
+                                        onInteract={this.questionDone}
+                                    >
+                                        Done
+                                    </AccessibleButton>
+                                    <AccessibleButton
                                         className="DotMenu"
-                                        onClick={() => this.setDotMenu(!this.state.showDotMenu)}
+                                        onInteract={() => this.setDotMenu(!this.state.showDotMenu)}
                                     >
                                         ...
                                         {this.state.showDotMenu &&
-                                            <div
+                                            <AccessibleButton
                                                 className="IReallyDontKnow"
-                                                tabIndex={1}
-                                                onClick={() => this.setDotMenu(false)}
+                                                onInteract={() => this.setDotMenu(false)}
                                             >
-                                                <p
+                                                <AccessibleButton
                                                     className="DontKnowButton"
-                                                    onClick={this.questionDontKnow}
+                                                    onInteract={this.questionDontKnow}
                                                 >
-                                                    I Really Don't Know
-                                                </p>
-                                            </div>
+                                                    {`I Really Don't Know`}
+                                                </AccessibleButton>
+                                            </AccessibleButton>
                                         }
-                                    </p>
+                                    </AccessibleButton>
                                 </>
                             }
                         </div>
@@ -426,12 +433,12 @@ class SessionQuestion extends React.Component<Props, State> {
 
                 {
                     this.props.includeRemove && !this.props.isPast &&
-                    <div className="Buttons">
-                        <hr />
-                        <p className="Remove" onClick={this.retractQuestion}>
-                            <Icon name="close" /> Remove
-                        </p>
-                    </div>
+                        <div className="Buttons">
+                            <hr />
+                            <AccessibleButton className="Remove" onInteract={this.retractQuestion}>
+                                <Icon name="close" /> Remove
+                            </AccessibleButton>
+                        </div>
                 }
             </div >
         );

--- a/src/components/includes/SessionQuestion.tsx
+++ b/src/components/includes/SessionQuestion.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import OutsideClickHandler from 'react-outside-click-handler';
 import { Icon, Loader, Button } from 'semantic-ui-react';
 import Moment from 'react-moment';
 import firebase from 'firebase/app';
@@ -10,6 +11,7 @@ import { firestore } from '../../firebase';
 import AccessibleButton from './AccessibleButton';
 import SelectedTags from './SelectedTags';
 import { onEnterOrSpace } from '../../utilities/a11y';
+import DropDownEntry from './DropDownEntry';
 
 // TODO_ADD_SERVER_CHECK
 const LOCATION_CHAR_LIMIT = 40;
@@ -199,6 +201,8 @@ class SessionQuestion extends React.Component<Props, State> {
     };
 
     questionDontKnow = () => {
+        this.setDotMenu(false);
+
         const batch = firestore.batch();
         const slotUpdate: Partial<FireQuestionSlot> = { status: 'unresolved' };
         const questionUpdate: Partial<FireQuestion> = { status: 'unresolved', answererId: '' };
@@ -265,12 +269,12 @@ class SessionQuestion extends React.Component<Props, State> {
                                         inline={true}
                                         size={'tiny'}
                                     /> : <Icon name="check" />}
-                                <div
+                                <AccessibleButton
                                     className="DoneButton"
-                                    onClick={this.toggleLocationTooltip}
+                                    onInteract={this.toggleLocationTooltip}
                                 >
                                     Done
-                                </div>
+                                </AccessibleButton>
                             </div>
                         </div>
                     }
@@ -284,7 +288,7 @@ class SessionQuestion extends React.Component<Props, State> {
                                 />
                                 <span className="userInformationName">
                                     {asker.firstName + ' ' + asker.lastName +
-                                        ' (' + asker.email.slice(0,asker.email.indexOf('@')) + ')'}
+                                        ' (' + asker.email.slice(0, asker.email.indexOf('@')) + ')'}
                                     {question.status === 'assigned' &&
                                         <>
                                             <span className="assigned"> is assigned
@@ -309,11 +313,11 @@ class SessionQuestion extends React.Component<Props, State> {
                                             Zoom Link
                                         </a>
                                     }
-                                    {this.props.isTA &&
+                                        {this.props.isTA &&
                                             question.location &&
                                             question.location.substr(0, 25) !== 'https://cornell.zoom.us/j' &&
                                             question.location
-                                    }</>)}
+                                        }</>)}
                         </div>
                         {(this.props.isTA || includeBookmark || this.props.includeRemove) &&
                             <p className={'Question' + studentCSS}>{question.content}</p>}
@@ -349,20 +353,20 @@ class SessionQuestion extends React.Component<Props, State> {
                         <hr />
                         <div className="TAButtons">
                             {question.status === 'unresolved' &&
-                                <AccessibleButton className="Begin" onInteract={this.assignQuestion}>
+                                <AccessibleButton className="TAQButton Begin" onInteract={this.assignQuestion}>
                                     Assign to Me
                                 </AccessibleButton>
                             }
                             {question.status === 'assigned' &&
                                 <>
                                     <AccessibleButton
-                                        className="Delete"
+                                        className="TAQButton Delete"
                                         onInteract={this.studentNoShow}
                                     >
                                         No show
                                     </AccessibleButton>
-                                    <AccessibleButton 
-                                        className="Done"
+                                    <AccessibleButton
+                                        className="TAQButton Done"
                                         onInteract={this.questionDone}
                                     >
                                         Done
@@ -372,20 +376,18 @@ class SessionQuestion extends React.Component<Props, State> {
                                         onInteract={() => this.setDotMenu(!this.state.showDotMenu)}
                                     >
                                         ...
-                                        {this.state.showDotMenu &&
-                                            <AccessibleButton
-                                                className="IReallyDontKnow"
-                                                onInteract={() => this.setDotMenu(false)}
-                                            >
-                                                <AccessibleButton
-                                                    className="DontKnowButton"
-                                                    onInteract={this.questionDontKnow}
+                                    </AccessibleButton>
+                                    {this.state.showDotMenu &&
+                                        <OutsideClickHandler onOutsideClick={() => this.setDotMenu(false)}>
+                                            <ul className="IReallyDontKnow" >
+                                                <DropDownEntry
+                                                    onSelect={this.questionDontKnow}
                                                 >
                                                     {`I Really Don't Know`}
-                                                </AccessibleButton>
-                                            </AccessibleButton>
-                                        }
-                                    </AccessibleButton>
+                                                </DropDownEntry>
+                                            </ul>
+                                        </OutsideClickHandler>
+                                    }
                                 </>
                             }
                         </div>
@@ -433,12 +435,12 @@ class SessionQuestion extends React.Component<Props, State> {
 
                 {
                     this.props.includeRemove && !this.props.isPast &&
-                        <div className="Buttons">
-                            <hr />
-                            <AccessibleButton className="Remove" onInteract={this.retractQuestion}>
-                                <Icon name="close" /> Remove
+                    <div className="Buttons">
+                        <hr />
+                        <AccessibleButton className="Remove" onInteract={this.retractQuestion}>
+                            <Icon name="close" /> Remove
                             </AccessibleButton>
-                        </div>
+                    </div>
                 }
             </div >
         );

--- a/src/components/includes/SessionView.tsx
+++ b/src/components/includes/SessionView.tsx
@@ -9,11 +9,11 @@ import SessionQuestionsContainer from './SessionQuestionsContainer';
 import { useCourseTags, useCourseUsersMap, useSessionQuestions, useSessionProfile, 
     useAskerQuestions } from '../../firehooks';
 import { filterUnresolvedQuestions } from '../../utilities/questions';
+import { onEnterOrSpace } from '../../utilities/a11y';
 import { updateVirtualLocation } from '../../firebasefunctions';
 import { firestore } from '../../firebase';
 
 import NotifBell from '../../media/notifBellWhite.svg';
-// import SessionAlertModal from './SessionAlertModal';
 
 type Props = {
     course: FireCourse;
@@ -248,9 +248,15 @@ const SessionView = (
 
             {undoQuestionId &&
                 <div className="undoContainer">
-                    <p className="undoClose" onClick={dismissUndo}>
+                    <div 
+                        role="button"
+                        tabIndex={0}
+                        className="undoClose"
+                        onKeyPress={onEnterOrSpace(dismissUndo)}
+                        onClick={dismissUndo}
+                    >
                         <Icon name="close" />
-                    </p>
+                    </div>
                     <p className="undoText">
                         {undoText}
                         <span

--- a/src/components/includes/TopBar.tsx
+++ b/src/components/includes/TopBar.tsx
@@ -1,7 +1,14 @@
 import React, { useEffect, useState } from 'react';
+import OutsideClickHandler from 'react-outside-click-handler';
 import { useHistory } from 'react-router';
 import { Icon } from 'semantic-ui-react';
+
 import { logOut } from '../../firebasefunctions';
+import { onEnterOrSpace, useEscape } from '../../utilities/a11y';
+
+import DropDownEntry from './DropDownEntry';
+
+const FEEDBACK_FORM = 'https://goo.gl/forms/7ozmsHfXYWNs8Y2i1';
 
 const TopBar = (props: {
     courseId: string;
@@ -19,44 +26,67 @@ const TopBar = (props: {
     const [image, setImage] = useState(props.user ? props.user.photoUrl : '/placeholder.png');
 
     const userPhotoUrl = props.user ? props.user.photoUrl : '/placeholder.png';
-    useEffect(() => setImage(userPhotoUrl), [userPhotoUrl]);
+    
+    useEffect(() => {
+        setImage(userPhotoUrl);
+    }, [userPhotoUrl]);
+
+    const toClose = React.useCallback(() => {
+        if (showMenu) {
+            setShowMenu(false); 
+        }
+    }, [showMenu]);
+
+    useEscape(toClose);
 
     return (
-        <div className="MenuBox" tabIndex={1} onBlur={() => setShowMenu(false)}>
+        <div className="MenuBox">
             <header className="topBar">
-                <div className="triggerArea" onClick={() => setShowMenu(!showMenu)}>
-                    <div className="userProfile">
+                <OutsideClickHandler display="contents" onOutsideClick={() => setShowMenu(false)}>
+                    <div
+                        role="button"
+                        tabIndex={0}
+                        aria-haspopup="true"
+                        aria-expanded={showMenu}
+                        className="triggerArea userProfile"
+                        onKeyPress={onEnterOrSpace(() => setShowMenu(!showMenu))}
+                        onClick={() => setShowMenu(!showMenu)}
+                    >
                         <img src={image} onError={() => setImage('/placeholder.png')} alt="User Profile" />
                         <span className="name">
                             {props.user ? props.user.firstName + ' ' + props.user.lastName : 'Loading...'}
                         </span>
-                    </div>
-                </div>
-            </header>
-            {showMenu && <>
-                <ul className="desktop logoutMenu" tabIndex={1}>
-                    <li onMouseDown={() => logOut()}>
-                        <span><Icon name="sign out" /></span> Log Out
-                    </li>
-                    <li onMouseDown={() => window.open('https://goo.gl/forms/7ozmsHfXYWNs8Y2i1', '_blank')}>
-                        <span><Icon name="edit" /></span>
-                        Send Feedback
-                    </li>
-                    {props.role === 'professor' &&
+                        {showMenu && <>
+                       
+                            <ul className="desktop logoutMenu">
+                                <DropDownEntry onSelect={() => logOut()}>
+                                    <span><Icon name="sign out" /></span> Log Out
+                                </DropDownEntry>
+                                <DropDownEntry onSelect={() => window.open(FEEDBACK_FORM, '_blank')}>
+                                    <span><Icon name="edit" /></span>
+                                    Send Feedback
+                                </DropDownEntry>
+               
+                                {props.role === 'professor' &&
                         <>
                             {props.context === 'professor' ?
-                                <li onMouseDown={() => history.push('/course/' + props.courseId)}>
+                                <DropDownEntry onSelect={() => history.push('/course/' + props.courseId)}>
                                     <span><Icon name="sync alternate" /></span>
                                     Switch View
-                                </li> : <li onMouseDown={() => history.push('/professor/course/' + props.courseId)}>
+                                </DropDownEntry> : 
+                                <DropDownEntry onSelect={() => history.push('/professor/course/' + props.courseId)}>
                                     <span><Icon name="sync alternate" /></span>
                                     Switch View
-                                </li>
+                                </DropDownEntry>
                             }
                         </>
-                    }
-                </ul>
-            </>}
+                                }
+                            </ul>
+                      
+                        </>}
+                    </div>
+                </OutsideClickHandler>
+            </header>
         </div>
     );
 };

--- a/src/styles/ModalMenu.scss
+++ b/src/styles/ModalMenu.scss
@@ -10,7 +10,6 @@
     padding-top: 42px;
     user-select: none;
     cursor: pointer;
-    outline: none;
 
     li {
         border: none;
@@ -34,6 +33,6 @@
     }
 }
 
-.logoutMenu li {
-    padding-left: 80px;
+.logoutMenu li div {
+    padding-left: 76px;
 }

--- a/src/styles/TopBar.scss
+++ b/src/styles/TopBar.scss
@@ -1,15 +1,14 @@
-.topBar .triggerArea,
+.topBar,
 .topBar:focus,
 .userProfile {
     display: flex;
     justify-content: flex-end;
     align-items: center;
     position: relative;
-    outline: none;
+
 }
 
 .MenuBox:focus {
-    outline: none;
 }
 
 .desktop.logoutMenu {
@@ -25,7 +24,11 @@
     padding: 0;
 
     li {
-        padding-top: 16px;
+        padding: 2px;
+    }
+
+    li div {
+        padding-top: 14px;
     }
 
     li:last-child {

--- a/src/styles/calendar/CalendarDaySelect.scss
+++ b/src/styles/calendar/CalendarDaySelect.scss
@@ -29,7 +29,7 @@ $red: #f67d7d;
 
         .LastWeek,
         .NextWeek:focus {
-            outline: 0;
+
         }
     }
 }
@@ -43,7 +43,7 @@ $red: #f67d7d;
 }
 
 .menuDate:focus {
-    outline: 0;
+
 }
 
 .menuDate {

--- a/src/styles/calendar/CalendarHeader.scss
+++ b/src/styles/calendar/CalendarHeader.scss
@@ -24,6 +24,7 @@
     }
 
     .CalendarHeader {
+        cursor: pointer;
         background: #7ab7fe;
         background-image: linear-gradient(74deg, #668ae9, #6db9ea);
         color: white;

--- a/src/styles/login/LoginButton.scss
+++ b/src/styles/login/LoginButton.scss
@@ -20,7 +20,6 @@
     padding: 1px;
     width: 247px;
     font-size: 16px;
-    outline: none;
     transition: all 0.17s $curve-standard;
     display: block;
     margin: auto;

--- a/src/styles/professor/ProfessorOHInfo.scss
+++ b/src/styles/professor/ProfessorOHInfo.scss
@@ -1,5 +1,5 @@
 .EditButtons:focus {
-    outline: none;
+
 }
 
 .ProfessorOHInfo {

--- a/src/styles/professor/ProfessorTagInfo.scss
+++ b/src/styles/professor/ProfessorTagInfo.scss
@@ -70,7 +70,7 @@
 
         .InputChildTag {
             &:focus {
-                outline: none;
+
             }
         }
 

--- a/src/styles/professor/ProfessorView.scss
+++ b/src/styles/professor/ProfessorView.scss
@@ -18,7 +18,7 @@
         background-color: transparent;
         border: none;
         color: #a0a0a0;
-        outline: none;
+
         user-select: none;
     }
 

--- a/src/styles/session/AddQuestion.scss
+++ b/src/styles/session/AddQuestion.scss
@@ -134,7 +134,6 @@
             box-sizing: border-box;
             border-radius: 3.25px;
             height: 78px;
-            outline: none;
 
             @media only screen and (min-width: $mobile-breakpoint) {
               border: 0.65px solid #979797;

--- a/src/styles/session/DiscussionQuestion.scss
+++ b/src/styles/session/DiscussionQuestion.scss
@@ -26,7 +26,6 @@
     }
 
     .Upvote:focus {
-        outline: none;
         box-shadow: none;
     }
 

--- a/src/styles/session/SessionAlertModal.scss
+++ b/src/styles/session/SessionAlertModal.scss
@@ -66,8 +66,7 @@
         flex-direction: row;
         align-content: stretch;
         text-align: center;
-        outline: none;
-
+ 
         button {
             border: none;
             width: 100%;

--- a/src/styles/session/SessionInformationHeader.scss
+++ b/src/styles/session/SessionInformationHeader.scss
@@ -131,7 +131,6 @@
                     border-radius: 5px;
                     color: rgba(53, 148, 241, 0.5);
                     font-size: 14px;
-                    outline: none;
                 }
 
                 .JoinButton {
@@ -157,7 +156,6 @@
                     background: #F3F5FC;
                     border-top-left-radius: 8px;
                     border-bottom-left-radius: 8px;
-                    outline: none;
                     border: none;
                     width: 48%;
                     height: 31px; 
@@ -190,7 +188,6 @@
                     display: flex;
                     justify-content: center;
                     button {
-                        outline: none;
                         border: none;
                         background-color: transparent;
                     }

--- a/src/styles/session/SessionNotification.scss
+++ b/src/styles/session/SessionNotification.scss
@@ -8,7 +8,6 @@
 
     button {
         position: absolute;
-        outline: none; 
         border: none;
         background-color: transparent;
         color: white;

--- a/src/styles/session/SessionQuestionsComponent.scss
+++ b/src/styles/session/SessionQuestionsComponent.scss
@@ -94,7 +94,6 @@
 
         .commentBtn {
             background-color: Transparent;
-            outline: none;
             border: none;
             cursor: pointer;
         }

--- a/src/styles/session/SessionQuestionsComponent.scss
+++ b/src/styles/session/SessionQuestionsComponent.scss
@@ -374,13 +374,14 @@
         }
 
         .TAButtons {
-            display: inline-block;
+            display: flex;
+            justify-content: center;
             padding-top: 10px;
             user-select: none;
 
-            p {
+            .TAQButton {
                 display: inline-block;
-                border-radius: 5px;
+                border-radius: 10px;
                 color: white;
                 padding: 2px 30px;
                 font-size: 15px;
@@ -390,17 +391,17 @@
             }
 
             .Delete {
-                border: 0.5px solid red;
+                border: 2px solid red;
                 color: red;
             }
 
             .Begin {
-                border: 0.5px solid $number-blue;
+                border: 2px solid $number-blue;
                 color: $number-blue;
             }
 
             .Done {
-                border: 0.5px solid $tag-blue;
+                border: 2px solid $tag-blue;
                 color: $tag-blue;
             }
 
@@ -428,8 +429,13 @@
                 right: 0;
                 z-index: 1;
 
-                p {
+                li {
+                    border-bottom: none;
+                }
+
+                div {
                     width: 200px;
+                    cursor: pointer;
                     color: black;
                     size: 13px;
                     font-weight: normal;

--- a/src/utilities/a11y.ts
+++ b/src/utilities/a11y.ts
@@ -1,0 +1,51 @@
+import React from 'react';
+
+type UniversalKeyboardEvent<T> =  React.KeyboardEvent<T> | KeyboardEvent;
+
+export const useEscape = (callback: () => void) => {
+    React.useEffect(() => {
+        const esc = onEscape(() => {
+            callback();
+        });
+
+        document.addEventListener("keydown", esc, false);
+    
+        return () => {
+            document.removeEventListener("keydown", esc, false);
+        };
+    }, [callback]);
+};
+
+export function onEscape<T>(fn: () => void): (event: UniversalKeyboardEvent<T>) => void {
+    return (event: UniversalKeyboardEvent<T>) => {
+        if (event.key === 'Escape') {
+            fn();
+        }
+    };
+}
+
+export function onEnterOrSpace<T>(fn: () => void): (event: UniversalKeyboardEvent<T>) => void {
+    return (event: UniversalKeyboardEvent<T>) => {
+        // eslint-disable-next-line no-console
+        console.log('Key: [' +event.key + ']');
+        if (event.key === 'Enter' || event.key === ' ') {
+            fn();
+        }
+    };
+}
+
+export function onSpace<T>(fn: () => void): (event: UniversalKeyboardEvent<T>) => void {
+    return (event: UniversalKeyboardEvent<T>) => {
+        if (event.key === ' ') {
+            fn();
+        }
+    };
+}
+
+export function onEnter<T>(fn: () => void): (event: React.KeyboardEvent<T>) => void {
+    return (event: UniversalKeyboardEvent<T>) => {
+        if (event.key === 'Enter') {
+            fn();
+        };
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3638,6 +3638,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-outside-click-handler@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@types/react-outside-click-handler/-/react-outside-click-handler-1.3.0.tgz#ccf0014032fc6ec286210f8a05d26a5c1f94cc96"
+  integrity sha512-BxQpd5GsbA9rjqLcM4lYp70VnvahgjMUeJ4OKi0A7QOsDLD2yUPswOVixtDpmvCu0PkRTfvMoStIR3gKC/L3XQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-router-dom@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.1.0.tgz#8baa84a7fa8c8e7797fb3650ca51f93038cb4caf"
@@ -14225,7 +14232,7 @@ react-onclickoutside@^6.7.1:
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.9.0.tgz#a54bc317ae8cf6131a5d78acea55a11067f37a1f"
   integrity sha512-8ltIY3bC7oGhj2nPAvWOGi+xGFybPNhJM0V1H8hY/whNcXgmDeaeoCMPPd8VatrpTsUWjb/vGzrmu6SrXVty3A==
 
-react-outside-click-handler@^1.2.0:
+react-outside-click-handler@^1.2.0, react-outside-click-handler@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/react-outside-click-handler/-/react-outside-click-handler-1.3.0.tgz#3831d541ac059deecd38ec5423f81e80ad60e115"
   integrity sha512-Te/7zFU0oHpAnctl//pP3hEAeobfeHMyygHB8MnjP6sX5OR8KHT1G3jmLsV3U9RnIYo+Yn+peJYWu+D5tUS8qQ==
@@ -16639,10 +16646,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.7.3:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+typescript@~3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 ua-parser-js@^0.7.18:
   version "0.7.20"


### PR DESCRIPTION
Also, resolve various linting errors.

### Summary <!-- Required -->

So this is my first volley at resolving #302 and getting rid of linting errors.

It...
- Ensures every "button" is accessible by keyboard, screenreader, and mouse.
- Fixes various issues with our button implementations
- Removes outline overrides so tab navigation is visible
- Starts adding aria roles to elements

*TODO*
- [X] Handle escape and space on menus.
- [X] ~Some static arrays can keep mapping on indices but I gotta eslint ignore them.~ (fixed in other PRs/resolved in this one)

I use Airbnb's outside click library instead of our old custom implementation - it handles accessibility and edge cases well, we didn't.

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->

Essentially we need to click every button and open every menu!

### Notes <!-- Optional -->

I upped TypeScript to 3.8.3 for compatibility reasons.

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
