### PR TITLE
Fix race condition with onSnapshot.

### DIFF
--- a/src/components/includes/SessionView.tsx
+++ b/src/components/includes/SessionView.tsx
@@ -235,6 +235,7 @@ const SessionView = (
             <SessionQuestionsContainer
                 isTA={isTa}
                 modality={session.modality}
+                session={session}
                 myVirtualLocation={(sessionProfile && sessionProfile.virtualLocation) || undefined}
                 questions={questions.filter(q => q.status === 'unresolved' || q.status === 'assigned')}
                 users={users}

--- a/src/firehooks.ts
+++ b/src/firehooks.ts
@@ -108,6 +108,21 @@ const allCoursesObservable: Observable<readonly FireCourse[]> = loggedIn$.pipe(
     switchMap(() => collectionData<FireCourse>(firestore.collection('courses'), 'courseId'))
 );
 
+const getAskerQuestionsQuery = (sessionId: string, askerId: string) => {
+    return firestore.collection('questions')
+        .where('sessionId', '==', sessionId)
+        .where('askerId', '==', askerId);
+};
+const useParameterizedAskerQuestions = createUseParamaterizedSingletonObservableHook(parameter => {
+    const [sessionId, askerId] = parameter.split('/');
+
+    const query = getAskerQuestionsQuery(sessionId, askerId);
+    return new SingletonObservable([], collectionData<FireQuestion>(query, 'questionId'));
+});
+export const useAskerQuestions = (sessionId: string, askerId: string): null | FireQuestion[] => {
+    return useParameterizedAskerQuestions(`${sessionId}/${askerId}`);
+}
+
 const allCoursesSingletonObservable = new SingletonObservable([], allCoursesObservable);
 
 export const useAllCourses: () => readonly FireCourse[] =


### PR DESCRIPTION
### Summary <!-- Required -->

The silent onError callback led to unreliable updates of question documents and thus virtual location issues.

From my debugging, we'd sometimes silently fail the onSnapshot call and/or load an un-updated version of the document and per the docs after onError is called onUpdate will never be called again.

Thus, letting the error silently fail proved to be a dangerous foot gun.

I've added a hook which queries for all questions within a given session that the user asked. We then filter this locally. This shouldn't be much more costly than a single document snapshot and it should avoid any potential race conditions.

### Test Plan <!-- Required -->

Test locally and in the development environment.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
