### PR TITLE
Fix editing assignment 'active' state.

### DIFF
--- a/src/components/includes/ProfessorTagInfo.tsx
+++ b/src/components/includes/ProfessorTagInfo.tsx
@@ -123,10 +123,16 @@ class ProfessorTagInfo extends React.Component<PropTypes, State> {
         const batch = firestore.batch();
 
         const parentTag = firestore.collection('tags').doc(this.state.tag.tagId);
+
         // deals w/ case where parent tag name is changed
         // no checking yet, like if A1 is changed to A0 but A0 already exists
-        if (this.props.tag && this.state.tag.name !== this.props.tag.name) {
-            batch.update(parentTag, { name: this.state.tag.name });
+        if (this.props.tag) {
+            if (this.state.tag.name !== this.props.tag.name || this.state.tag.active !== this.props.tag.active) {
+                batch.update(parentTag, {
+                    name: this.state.tag.name, 
+                    active: this.state.tag.active
+                });
+            }
         }
 
         // deleted tags


### PR DESCRIPTION

### Summary <!-- Required -->

Both the name of the assignment _and_ the active state should be updated if they change.

### Test Plan

- Create a new assignment
- Click the edit button
- Change the active/inactive toggle
- Click save
- Ensure the change survives a refresh

### Notes

This was a result of an incomplete implementation when switching to Firestore

### Breaking Changes

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
