### PR TITLE
WIP: Implement assignment deletion support.

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -20,8 +20,8 @@ import { auth, firestore } from '../firebase';
 
 import AdminView from './pages/AdminView';
 import LoginView from './pages/LoginView';
-import ProfessorView from './pages/ProfessorView';
 import SplitView from './pages/SplitView';
+import ProfessorHoursView from './pages/ProfessorHoursView';
 import ProfessorTagsView from './pages/ProfessorTagsView';
 import ProfessorRoles from './pages/ProfessorRoles';
 import ProfessorDashboardView from './pages/ProfessorDashboardView';
@@ -216,7 +216,7 @@ export default () => {
                     />
                     <PrivateRoute
                         path="/professor/course/:courseId"
-                        component={ProfessorView}
+                        component={ProfessorHoursView}
                         exact={true}
                         requireProfessor
                     />

--- a/src/components/includes/Confirmation.tsx
+++ b/src/components/includes/Confirmation.tsx
@@ -1,0 +1,89 @@
+import * as React from "react";
+
+import {createContext, useCallback,useContext, useState} from "react";
+import { Confirm } from "semantic-ui-react";
+
+const ConfirmationContext = createContext({
+    openConfirm: (() => {}) as (properties: ConfirmProperties) => void
+});
+
+interface ConfirmProperties {
+    header?: string;
+    content: string;
+    callback: (confirmed: boolean) => void;
+}
+
+export const useConfirm = () => {
+    const { openConfirm } = useContext(ConfirmationContext);
+  
+    const confirm = ({ header, content }: {
+        header?: string;
+        content: string;
+    }) =>
+        new Promise<void>((res, rej) => {
+            openConfirm({ 
+                callback(confirmed) {
+                    if (confirmed) {
+                        res();
+                    } else {
+                        rej(new Error("Did not confirm."));
+                    }
+                },
+                header,
+                content
+            });
+        });
+  
+    return { confirm };
+};
+
+const ConfirmationProvider: React.FunctionComponent = ({ children }) => {
+    const [open, setOpen] = useState(false);
+    const [header, setHeader] = useState<string | undefined>(undefined);
+    const [[callback], setCallback] = useState<[(confirmed: boolean) => void]>([() => {}]);
+    const [content, setContent] = useState<string | undefined>(undefined);
+
+    const openConfirm = useCallback((properties: ConfirmProperties) => {
+        setOpen(true);
+
+        setCallback([properties.callback]);
+        setHeader(properties.header);
+        setContent(properties.content);
+    }, []);
+
+    const clear = useCallback(() => {
+        setHeader(undefined);
+        setContent(undefined);
+    }, []);
+
+    return (
+        <ConfirmationContext.Provider value={{ openConfirm }}>
+            <Confirm
+                header={header}
+                content={content}
+                open={open}
+                onCancel={
+                    () => {
+                        setOpen(false);
+
+                        callback(false);
+
+                        clear();
+                    }
+                }
+                onConfirm={
+                    () => {
+                        setOpen(false);
+
+                        callback(true);
+
+                        clear();
+                    }
+                }
+            />
+            {children}
+        </ConfirmationContext.Provider>
+    );
+};
+
+export default ConfirmationProvider;

--- a/src/components/includes/ProfessorAddNew.tsx
+++ b/src/components/includes/ProfessorAddNew.tsx
@@ -13,13 +13,13 @@ const ProfessorAddNew = (props: {
     const text = props.taOptions ? 'Add New Office Hour' : 'Add New Assignment';
     return (
         <div className="ProfessorAddNew">
-            <div className={'Add ' + !editVisible}>
+            <div className={`Add ${!editVisible ? 'Show' : 'Hide'}`}>
                 <button type="button" className="NewOHButton" onClick={() => setEditVisible(true)}>
                     <Icon name="plus" />
                     {text}
                 </button>
             </div>
-            <div className={'ExpandedAdd ' + editVisible}>
+            <div className={`ExpandedAdd ${editVisible ? 'Show' : 'Hide'}`}>
                 <div className="NewOHHeader">
                     <button type="button" className="ExpandedNewOHButton" onClick={() => setEditVisible(false)}>
                         <Icon name="plus" />

--- a/src/components/includes/ProfessorCalendarRow.tsx
+++ b/src/components/includes/ProfessorCalendarRow.tsx
@@ -26,8 +26,8 @@ const ProfessorCalendarRow = (props: {
     updateDeleteVisible: Function;
 }) => {
 
-    const toggleEdit = (row: number) => {
-        props.handleEditToggle(props.dayNumber, row);
+    const toggleEdit = (row: number, state?: boolean) => {
+        props.handleEditToggle(props.dayNumber, row, state);
     };
 
     const updateDeleteInfo = (dayIndex: number, rowIndex: number) => {
@@ -63,7 +63,7 @@ const ProfessorCalendarRow = (props: {
         (session, i) => {
             return (
                 <tbody
-                    className={'Pair ' + props.isExpanded[i] + ' ' + (i % 2 === 0 ? 'odd' : 'even')}
+                    className={`Pair  ${props.isExpanded[i] ? 'Open' : 'Closed'} ${(i % 2 === 0 ? 'odd' : 'even')}`}
                     key={session.sessionId}
                 >
                     <tr className="Preview">
@@ -80,7 +80,7 @@ const ProfessorCalendarRow = (props: {
                             <button
                                 type="button"
                                 className="Edit"
-                                onClick={() => toggleEdit(i)}
+                                onClick={() => toggleEdit(i, true)}
                             >
                                 <Icon name="pencil" />
                             </button>
@@ -96,7 +96,7 @@ const ProfessorCalendarRow = (props: {
                         </td>
                     </tr>
                     <tr>
-                        <td colSpan={5} className={'ExpandedEdit ' + props.isExpanded[i]} >
+                        <td colSpan={5} className={`ExpandedEdit ${props.isExpanded[i] ? 'Open' : 'Closed'}`} >
                             <ProfessorOHInfo
                                 key={props.sessions[i].sessionId}
                                 session={props.sessions[i]}

--- a/src/components/includes/ProfessorCalendarTable.tsx
+++ b/src/components/includes/ProfessorCalendarTable.tsx
@@ -49,7 +49,7 @@ class ProfessorCalendarTable extends React.Component<Props, State> {
         this.setState({ isExpanded });
     }
 
-    toggleEdit = (day: number, row: number, forceClose?: boolean) => {
+    toggleEdit = (day: number, row: number, forceState?: boolean) => {
         const cDay = this.state.currentDay;
         const cRow = this.state.currentRow;
 
@@ -58,8 +58,8 @@ class ProfessorCalendarTable extends React.Component<Props, State> {
             isExpanded[cDay][cRow] = false;
         }
 
-        if (forceClose) {
-            isExpanded[day][row] = false;
+        if (typeof forceState === "boolean") {
+            isExpanded[day][row] = forceState;
         } else {
             isExpanded[day][row] = !isExpanded[day][row];
         }

--- a/src/components/includes/ProfessorOHInfo.tsx
+++ b/src/components/includes/ProfessorOHInfo.tsx
@@ -19,7 +19,7 @@ const ProfessorOHInfo = (props: {
     isNewOH: boolean;
     taOptions: DropdownItemProps[];
     taUserIdsDefault?: number[];
-    toggleEdit: Function;
+    toggleEdit: () => void;
 }) => {
     const session = props.session || undefined;
 

--- a/src/components/includes/ProfessorTagsRow.tsx
+++ b/src/components/includes/ProfessorTagsRow.tsx
@@ -1,7 +1,14 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import { Icon } from 'semantic-ui-react';
-import 'react-datepicker/dist/react-datepicker.css';
+
+import { firestore } from '../../firebase';
+import { removeAssignment } from '../../functions/tags';
+import { useConfirm } from './Confirmation';
+
 import ProfessorTagInfo from './ProfessorTagInfo';
+
+import 'react-datepicker/dist/react-datepicker.css';
+
 
 const ProfessorTagsRow = (props: {
     tag: FireTag;
@@ -10,8 +17,34 @@ const ProfessorTagsRow = (props: {
     courseId: string;
 }) => {
     const [showEdit, setShowEdit] = useState(false);
+
+    const {tag, childTags} = props;
+
+    const remove = useCallback((): Promise<void> => removeAssignment(firestore, tag, childTags), [tag, childTags]);
+
+    const {confirm} = useConfirm();
+
+    const confirmDelete = useCallback(() => {
+        // eslint-disable-next-line no-console
+        console.log("confirming...", confirm);
+        // TODO(ewlsh): Use a good dialog library.
+        // eslint-disable-next-line no-restricted-globals, no-alert
+        confirm({
+            content: `Are you sure you want to delete the ${tag.name} tag?`
+        }).then(() => {
+            // eslint-disable-next-line no-console
+            console.log('removing...');
+            return remove();
+        })
+        // eslint-disable-next-line no-console
+            .then(() => console.log("Assignment successfully deleted."))
+        // eslint-disable-next-line no-console
+            .catch(err => console.error(err));
+        
+    }, [tag, confirm, remove]);
+
     return (
-        <tbody className={'Pair ' + showEdit + ' ' + (props.index % 2 === 0 ? 'odd' : 'even')} key={props.tag.tagId}>
+        <tbody className={`Pair ${showEdit ? 'Open' : 'Closed'} ${props.index % 2 === 0 ? 'odd' : 'even'}`} key={props.tag.tagId}>
             <tr className="Preview">
                 <td>
                     <span className={'AssignmentTag'} key={props.tag.tagId}>
@@ -31,13 +64,16 @@ const ProfessorTagsRow = (props: {
                 </td>
                 <td>{props.tag.active ? 'Active' : 'Inactive'}</td>
                 <td>
-                    <button type="button" className="Edit" onClick={() => setShowEdit(!showEdit)}>
+                    <button type="button" className="Edit" onClick={() => setShowEdit(true)}>
                         <Icon name="pencil" />
+                    </button>
+                    <button type="button" className="Delete" onClick={() => confirmDelete()}>
+                        <Icon name="trash" />
                     </button>
                 </td>
             </tr>
             <tr>
-                <td className={'ExpandedEdit ' + showEdit} colSpan={4}>
+                <td className={`ExpandedEdit ${showEdit ? 'Open' : 'Closed'}`} colSpan={4}>
                     <ProfessorTagInfo
                         isNew={false}
                         cancelCallback={() => setShowEdit(!showEdit)}

--- a/src/components/includes/ProfessorTagsTable.tsx
+++ b/src/components/includes/ProfessorTagsTable.tsx
@@ -21,7 +21,7 @@ const ProfessorTagsTable = (props: { courseId: string }) => {
                             <th>Assignment</th>
                             <th>Tags</th>
                             <th id="statusColumn">Status</th>
-                            <th>Edit</th>
+                            <th>Actions</th>
                         </tr>
                     </tbody>
                     {tags

--- a/src/components/includes/ProfessorView.tsx
+++ b/src/components/includes/ProfessorView.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+
+import ConfirmationProvider from './Confirmation';
+
+const ProfessorView: React.FunctionComponent = ({children}) => {
+    return (
+        <ConfirmationProvider>
+            <div className="ProfessorView">
+                {children}
+            </div>
+        </ConfirmationProvider>
+    );
+};
+
+export default ProfessorView;

--- a/src/components/pages/ProfessorDashboardView.tsx
+++ b/src/components/pages/ProfessorDashboardView.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { Dropdown, DropdownProps } from 'semantic-ui-react';
+
 import TopBar from '../includes/TopBar';
 import ProfessorSidebar from '../includes/ProfessorSidebar';
+import ProfessorView from '../includes/ProfessorView';
 import TagsBarChart from '../includes/TagsBarChart';
 
 import { useMyUser, useQuery, useCourse } from '../../firehooks';
@@ -92,7 +94,7 @@ const ProfessorDashboardView = ({ match: { params: { courseId } } }: RouteCompon
     const course = useCourse(courseId);
 
     return (
-        <div className="ProfessorView">
+        <ProfessorView>
             <ProfessorSidebar courseId={courseId} code={course ? course.code : 'Loading'} selected={2} />
             <TopBar courseId={courseId} user={useMyUser()} context="professor" role="professor" />
             <section className="rightOfSidebar">
@@ -131,7 +133,7 @@ const ProfessorDashboardView = ({ match: { params: { courseId } } }: RouteCompon
                     }
                 </div>
             </section>
-        </div>
+        </ProfessorView>
     );
 };
 

--- a/src/components/pages/ProfessorHoursView.tsx
+++ b/src/components/pages/ProfessorHoursView.tsx
@@ -11,6 +11,7 @@ import ProfessorDelete from '../includes/ProfessorDelete';
 import ProfessorSettings from '../includes/ProfessorSettings';
 import TopBar from '../includes/TopBar';
 import ProfessorSidebar from '../includes/ProfessorSidebar';
+import ProfessorView from '../includes/ProfessorView';
 import CalendarWeekSelect from '../includes/CalendarWeekSelect';
 
 import { useCourse, useMyUser } from '../../firehooks';
@@ -18,7 +19,7 @@ import { firestore, collectionData } from '../../firebase';
 
 const ONE_DAY = 24 /* hours */ * 60 /* minutes */ * 60 /* seconds */ * 1000 /* millis */;
 
-const ProfessorView = ({ match: { params: { courseId } } }: RouteComponentProps<{ courseId: string }>) => {
+const ProfessorHoursView = ({ match: { params: { courseId } } }: RouteComponentProps<{ courseId: string }>) => {
     const week = new Date();
     week.setHours(0, 0, 0, 0);
     const daysSinceMonday = ((week.getDay() - 1) + 7) % 7;
@@ -84,7 +85,7 @@ const ProfessorView = ({ match: { params: { courseId } } }: RouteComponentProps<
     );
 
     return (
-        <div className="ProfessorView">
+        <ProfessorView>
             <ProfessorSidebar
                 courseId={courseId}
                 code={course ? course.code : 'Loading'}
@@ -138,8 +139,8 @@ const ProfessorView = ({ match: { params: { courseId } } }: RouteComponentProps<
                     </div>
                 </div>
             </section>
-        </div>
+        </ProfessorView>
     );
 };
 
-export default ProfessorView;
+export default ProfessorHoursView;

--- a/src/components/pages/ProfessorPeopleView.tsx
+++ b/src/components/pages/ProfessorPeopleView.tsx
@@ -5,6 +5,7 @@ import { switchMap } from 'rxjs/operators';
 import moment from 'moment';
 import { DateRangePicker } from 'react-dates';
 import ProfessorSidebar from '../includes/ProfessorSidebar';
+import ProfessorView from '../includes/ProfessorView';
 import QuestionsPieChart from '../includes/QuestionsPieChart';
 import QuestionsLineChart from '../includes/QuestionsLineChart';
 import QuestionsBarChart from '../includes/QuestionsBarChart';
@@ -175,7 +176,7 @@ const ProfessorPeopleView = (props: RouteComponentProps<{ courseId: string }>) =
 
     const chartYMax = (questions[busiestSessionIndex] && questions[busiestSessionIndex].length) || 0;
     return (
-        <div className="ProfessorView">
+        <ProfessorView>
             <ProfessorSidebar courseId={courseId} code={(course && course.code) || 'Loading'} selected={3} />
             <TopBar courseId={courseId} user={user} context="professor" role="professor" />
             <section className="rightOfSidebar">
@@ -274,7 +275,7 @@ const ProfessorPeopleView = (props: RouteComponentProps<{ courseId: string }>) =
                     }
                 </div>
             </section>
-        </div>
+        </ProfessorView>
     );
 };
 

--- a/src/components/pages/ProfessorRoles.tsx
+++ b/src/components/pages/ProfessorRoles.tsx
@@ -3,6 +3,7 @@ import { RouteComponentProps } from 'react-router';
 import TopBar from '../includes/TopBar';
 import ProfessorSidebar from '../includes/ProfessorSidebar';
 import ProfessorRolesTable from '../includes/ProfessorRolesTable';
+import ProfessorView from '../includes/ProfessorView';
 import { useMyUser, useCourse } from '../../firehooks';
 
 const ProfessorDashboardView = ({ match: { params: { courseId } } }: RouteComponentProps<{ courseId: string }>) => {
@@ -10,7 +11,7 @@ const ProfessorDashboardView = ({ match: { params: { courseId } } }: RouteCompon
     const course = useCourse(courseId);
 
     return (
-        <div className="ProfessorView">
+        <ProfessorView>
             <ProfessorSidebar courseId={courseId} code={course ? course.code : 'Loading'} selected={4} />
             <TopBar courseId={courseId} user={user} context="professor" role="professor" />
             <section className="rightOfSidebar">
@@ -18,7 +19,7 @@ const ProfessorDashboardView = ({ match: { params: { courseId } } }: RouteCompon
                     <ProfessorRolesTable courseId={courseId} />
                 </div>
             </section>
-        </div>
+        </ProfessorView>
     );
 };
 

--- a/src/components/pages/ProfessorTagsView.tsx
+++ b/src/components/pages/ProfessorTagsView.tsx
@@ -4,6 +4,7 @@ import ProfessorTagsTable from '../includes/ProfessorTagsTable';
 import ProfessorAddNew from '../includes/ProfessorAddNew';
 import TopBar from '../includes/TopBar';
 import ProfessorSidebar from '../includes/ProfessorSidebar';
+import ProfessorView from '../includes/ProfessorView';
 import { useMyUser, useCourse } from '../../firehooks';
 
 const ProfessorTagsView = (
@@ -12,7 +13,7 @@ const ProfessorTagsView = (
     const user = useMyUser();
     const course = useCourse(courseId);
     return (
-        <div className="ProfessorView">
+        <ProfessorView>
             <ProfessorSidebar
                 courseId={courseId}
                 code={course ? course.code : 'Loading...'}
@@ -27,7 +28,7 @@ const ProfessorTagsView = (
                     </div>
                 </div>
             </section>
-        </div>
+        </ProfessorView>
     );
 };
 

--- a/src/functions/tags.ts
+++ b/src/functions/tags.ts
@@ -1,0 +1,30 @@
+import * as firebase from "firebase";
+
+const TAG_COLLECTION = 'tags';
+
+/**
+ * Removes an assignment and (optionally) any child tags.
+ * @param firestore a firestore instance
+ * @param tag the tag to remove
+ * @param childTags any child tags to remove
+ */
+export function removeAssignment(
+    firestore: firebase.firestore.Firestore,
+    tag: FireTag,
+    childTags: FireTag[] = []
+) {
+    const batch = firestore.batch();
+      
+    const tags = firestore.collection(TAG_COLLECTION);
+    const parentTag = tags.doc(tag.tagId);
+
+    // Delete parent tag.
+    batch.delete(parentTag);
+
+    // Delete child tags.
+    childTags.forEach(firetag => {
+        batch.delete(tags.doc(firetag.tagId));
+    });
+
+    return batch.commit();
+}

--- a/src/styles/professor/ProfessorAddNew.scss
+++ b/src/styles/professor/ProfessorAddNew.scss
@@ -1,9 +1,9 @@
 .ProfessorAddNew {
-    .Add.false {
+    .Add.Hide {
         display: none;
     }
 
-    .ExpandedAdd.false {
+    .ExpandedAdd.Hide {
         display: none;
     }
 

--- a/src/styles/professor/ProfessorCalendarRow.scss
+++ b/src/styles/professor/ProfessorCalendarRow.scss
@@ -13,14 +13,16 @@ $odd-color: #ffffff;
     background-color: $even-color;
 }
 
-.Pair.true {
+.Pair.Open {
     .Preview {
         color: white;
         background-color: #898989;
+        
         .Edit, .Delete {
             color: white;
         }
     }
+
     .ExpandedEdit {
         border-bottom: 1px solid #d9d9d9;
     }
@@ -31,7 +33,7 @@ $odd-color: #ffffff;
         width: 35%;
     }
 
-    .ExpandedEdit.false {
+    .ExpandedEdit.Closed {
         display: none;
     }
 

--- a/src/styles/professor/ProfessorDelete.scss
+++ b/src/styles/professor/ProfessorDelete.scss
@@ -1,4 +1,4 @@
-.ProfessorDelete.true {
+.ProfessorDelete.Open {
     display: block;
 }
 

--- a/src/styles/professor/ProfessorOHInfo.scss
+++ b/src/styles/professor/ProfessorOHInfo.scss
@@ -38,7 +38,7 @@
                 font-size: 14px;
             }
 
-            .AddTAButton.true {
+            .AddTAButton.Open {
                 color:gainsboro;
             }
         }

--- a/src/styles/professor/ProfessorTagsRow.scss
+++ b/src/styles/professor/ProfessorTagsRow.scss
@@ -1,6 +1,12 @@
 .ProfessorTagsTable {
     .Tags {
         .Pair {
+            .ChildTagSeparator {
+                margin: 0 10px;
+                color: #8f8f90;
+                font-size: 10px;
+                vertical-align: text-bottom;
+            }
 
             .ChildTagSeparator {
                 margin: 0 10px;
@@ -9,14 +15,20 @@
                 vertical-align: text-bottom;
             }
 
-            .AssignmentTag {
+            .Preview .AssignmentTag {
                 font-weight: 500;
                 color: $text-grey;
             }
 
-            &.true {
+            &.Open {
                 .ChildTagSeparator {
                     color: #ffffff;
+                }
+
+                .Preview {                    
+                    .AssignmentTag {
+                        color: white;
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Summary <!-- Required -->

This primarily adds the ability to delete assignments but also incorporates Semantic UI's modal system into the code base instead of relying on browser prompts.

If we don't enable assignment deletion I'd still like to incorporate the modal system.

- Adds a hook for semantic UI's confirmation modal.
- Cleans up open/close CSS
- Removes edit-button toggle

### Test Plan

- Create an assignment
- Delete the assignment
- Verify the deletion survives a refresh and the tag (and its children) are gone from the datastore

### Notes

Seems odd we don't support deleting assignments, *though we should ensure this doesn't break rendering questions with deleted tags* and discuss if deleted tags present a problem.

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
