### PR TITLE
Wrapped dot menu in a div to fix stretching problem

### DIFF
--- a/src/components/includes/SessionQuestion.tsx
+++ b/src/components/includes/SessionQuestion.tsx
@@ -194,9 +194,11 @@ class SessionQuestion extends React.Component<Props, State> {
             <div className="QueueQuestions">
                 <div className="TopBar">
                     {!this.props.includeRemove && includeBookmark && <div className="Bookmark" />}
-                    <p className={'Order ' + (question.status === 'assigned' ? 'assigned' : '')}>
-                        {question.status === 'assigned' ? '•••' : this.getDisplayText(this.props.index)}
-                    </p>
+                    <div>
+                        <p className={'Order ' + (question.status === 'assigned' ? 'assigned' : '')}>
+                            {question.status === 'assigned' ? '•••' : this.getDisplayText(this.props.index)}
+                        </p>
+                    </div>
                     {this.props.includeRemove && this.props.modality !== 'virtual' &&
                         <div className="LocationPin">
                             <Icon


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
Fixed issue #400 by wrapping the dot menu in a div. 

<!-- Add your summary here -->

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->
Tested this on professor, TA, and student view, and the dot menu no longer appears stretched.

<!-- Briefly describe how you test you changes. -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
