### PR TITLE
Jeremy/newquestionnotif

### DIFF
--- a/src/components/includes/SessionQuestionsContainer.tsx
+++ b/src/components/includes/SessionQuestionsContainer.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Icon } from 'semantic-ui-react';
 import moment from 'moment';
 import SessionQuestion from './SessionQuestion';
+import addNotification from 'react-push-notification';
 import { useAskerQuestions } from '../../firehooks';
 
 const SHOW_FEEDBACK_QUEUE = 4;
@@ -110,10 +111,11 @@ const SessionQuestionsContainer = (props: Props) => {
 
     // Only display the top 10 questions on the queue
     const shownQuestions = allQuestions.slice(0, Math.min(allQuestions.length, NUM_QUESTIONS_SHOWN));
+
     // Make sure that the data has loaded and user has a question
     if (shownQuestions && myQuestion) {
         // Get user's position in queue (0 indexed)
-        const myQuestionIndex = allQuestions.indexOf(myQuestion);
+        const myQuestionIndex = allQuestions.findIndex(elt => elt.questionId === myQuestion.questionId);
         // Update tab with user position
         document.title = '(' + (1 + myQuestionIndex) + ') Queue Me In';
         // if user is up and we haven't already sent a notification, send one.
@@ -121,8 +123,10 @@ const SessionQuestionsContainer = (props: Props) => {
             window.localStorage.setItem('questionUpNotif', 'sent');
             setSentNotification(true);
             try {
-                const n = new Notification('Your question is up!');
-                setTimeout(n.close.bind(n), 4000);
+                addNotification({
+                    title: 'Your question is up!',
+                    native: true
+                });
             } catch (error) {
                 // Do nothing. iOS crashes because Notification isn't defined
             }

--- a/src/components/includes/SessionQuestionsContainer.tsx
+++ b/src/components/includes/SessionQuestionsContainer.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { Icon } from 'semantic-ui-react';
 import moment from 'moment';
-import SessionQuestion from './SessionQuestion';
 import addNotification from 'react-push-notification';
+import SessionQuestion from './SessionQuestion';
 import { useAskerQuestions } from '../../firehooks';
 
 const SHOW_FEEDBACK_QUEUE = 4;


### PR DESCRIPTION
### Summary <!-- Required -->
I fixed the notification bug that prevented the "Your question is up!" notification from working.
<!-- Provide a general summary of your changes in the Title above -->
I found that there was a bug in the code that always made the index of myQuestion -1 in the allQuestions array, and I changed it so that it actually returns the actual index of myQuestion. By doing this, I made sure the notification was actually fired when myQuestion has index 0 in the array.
<!-- Add your summary here -->
I realized with a few console.log() statements that the useAskerQuestions method was returning objects that had properties that did not exactly match the properties of question objects in the allQuestions array. As a result, myQuestion, which depends on myQuestions which is called from useAskerQuestions(sessionId, myUserId), had different properties compared to question objects in the allQuestions array. This made it so that the original code, allQuestions.indexOf(myQuestion), was always returning -1, which is why the notification was never fired.

![Screen Shot 2020-10-21 at 7 51 53 PM](https://user-images.githubusercontent.com/40004551/96805947-65fee780-13d8-11eb-8fec-c4148e7cd83c.png)

I changed this line to allQuestions.findIndex(elt => elt.questionId === myQuestion.questionId) so that regardless of different properties, it finds the question in allQuestions with the specific id that matches myQuestion. After that, I also changed the notification code to call addNotification() to be consistent with how we are handling notifications with React.
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->

<!-- Briefly describe how you test you changes. -->

- Test the standard case of adding the first question in the queue to see if a notification is fired
- Afterwards, login with two or more student accounts and create two or more questions in a queue---make sure the account you are specifically testing for the notification does not start at index 0 in the queue immediately
- Subsequently delete notifications until the account you are testing with is up, and see if a notification is fired when that question has index 0

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
