### PR TITLE
Fix discrepancy between student question number and position of stude…

### DIFF
--- a/src/components/includes/SessionQuestionsContainer.tsx
+++ b/src/components/includes/SessionQuestionsContainer.tsx
@@ -109,7 +109,7 @@ const SessionQuestionsContainer = (props: Props) => {
         return null;
     }, [myQuestions]);
 
-    const myQuestionIndex = allQuestions.find(question => question.questionId === myQuestion?.questionId)   
+    const myQuestionIndex = allQuestions.findIndex(question => question.questionId === myQuestion?.questionId)   
 
     // Only display the top 10 questions on the queue
     const shownQuestions = allQuestions.slice(0, Math.min(allQuestions.length, NUM_QUESTIONS_SHOWN));
@@ -177,14 +177,14 @@ const SessionQuestionsContainer = (props: Props) => {
                     This queue has closed and is no longer accepting new questions.
                 </div>
             }
-            {shownQuestions && myQuestion && myQuestionIndex &&
+            {shownQuestions && myQuestion &&
                 <StudentMyQuestion
                     user={props.user}
                     questionId={myQuestion.questionId}
                     studentQuestion={myQuestion}
                     modality={props.modality}
                     tags={props.tags}
-                    index={allQuestions.indexOf(myQuestionIndex)}
+                    index={myQuestionIndex}
                     triggerUndo={props.triggerUndo}
                     isPast={props.isPast}
                     myUserId={props.myUserId}

--- a/src/components/includes/SessionQuestionsContainer.tsx
+++ b/src/components/includes/SessionQuestionsContainer.tsx
@@ -109,6 +109,8 @@ const SessionQuestionsContainer = (props: Props) => {
         return null;
     }, [myQuestions]);
 
+    const myQuestionIndex = allQuestions.find(question => question.questionId === myQuestion?.questionId)   
+
     // Only display the top 10 questions on the queue
     const shownQuestions = allQuestions.slice(0, Math.min(allQuestions.length, NUM_QUESTIONS_SHOWN));
 
@@ -175,14 +177,14 @@ const SessionQuestionsContainer = (props: Props) => {
                     This queue has closed and is no longer accepting new questions.
                 </div>
             }
-            {shownQuestions && myQuestion &&
+            {shownQuestions && myQuestion && myQuestionIndex &&
                 <StudentMyQuestion
                     user={props.user}
                     questionId={myQuestion.questionId}
                     studentQuestion={myQuestion}
                     modality={props.modality}
                     tags={props.tags}
-                    index={allQuestions.indexOf(myQuestion)}
+                    index={allQuestions.indexOf(myQuestionIndex)}
                     triggerUndo={props.triggerUndo}
                     isPast={props.isPast}
                     myUserId={props.myUserId}


### PR DESCRIPTION
…nt in the queue

### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Add your summary here -->
There was a bug causing the student question number to appear as 0 regardless of the number of students ahead. This bug was caused by trying to find the index of the myQuestion object in the allQuestions list which contains a different type of objects. This always returned -1. I fixed this bug by finding the index of the object in the allQuestions list with the same questionId as myQuestion.

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->
<!-- Briefly describe how you test you changes. -->
Use several accounts to join the queue. The question numbers in each student view should correspond to the question numbers in the professor view (they should no longer be 0). When questions are removed from the queue the numbers in the student view should update accordingly. 

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
