### PR TITLE
Support adding roles to pending users.

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -7,6 +7,95 @@ admin.initializeApp();
 
 const db = admin.firestore();
 
+/** Adds new roles to a user without them being in QMI's system
+ * Not inclusive: Still need to consider users that are
+ * already in the system. (THIS CASE IS HANDLED BY NOT INCLDUING THEM IN THE
+ * pendingUsers COLLECTIONIN THE FIRST PLACE)
+ */
+exports.onUserCreate = functions.firestore
+    .document('users/{userId}')
+    .onCreate(async (snap, context) => {
+        const userId = context.params.userId;
+
+        // get the user doc
+        const userRef = db.collection('users').doc(userId);
+        const userDoc = await userRef.get();
+        const user = userDoc.data() as FireUser;
+
+        const currentRoles = user.roles;
+        const email = user.email;
+
+        // match this email with a user in the pendingUsers collection
+        const pendingUsersSnap = await db.collection('pendingUsers').where('email', '==', email).get();
+
+        pendingUsersSnap.forEach(async doc => {
+
+            // delete the pendingUsers entry because they now exist in QMI...
+            db.collection('pendingUsers').doc(doc.id).delete();
+
+            // get the users's roles map as a Map<string, FireCourseRole>
+            const newRoles = (doc.data() as FirePendingUser).roles;
+
+            const taCourseIds: string[] = [];
+            const profCourseIds: string[] = [];
+
+            for (const [courseId, role] of Object.entries(newRoles)) {
+
+                if (role === 'ta') {
+                    taCourseIds.push(courseId);
+                } else if (role === 'professor') {
+                    profCourseIds.push(courseId);
+                }
+            }
+            
+            const batch = db.batch();
+
+            // and update the newly-created user with their new roles
+            userRef.update({
+                courses: [...taCourseIds, ...profCourseIds],
+                roles: {...currentRoles, ...newRoles}
+            })
+
+            const taCourseDocs = await Promise.all(
+                taCourseIds.map(courseId => db.collection('courses').doc(courseId).get()));
+                        
+            const profCourseDocs = await Promise.all(
+                profCourseIds.map(courseId => db.collection('courses').doc(courseId).get()));
+
+            taCourseDocs.map(doc => {
+                const course = doc.data() as FireCourse;
+
+                batch.update(
+                    db.collection('courses').doc(course.courseId),
+                    insertTaOrProf(course, userId, 'ta')
+                );
+            });
+
+            profCourseDocs.map(doc => {
+                const course = doc.data() as FireCourse;
+
+                batch.update(
+                    db.collection('courses').doc(course.courseId),
+                    insertTaOrProf(course, userId, 'professor')
+                );
+            });
+
+            batch.commit();
+        });
+
+    });
+
+const insertTaOrProf = (course: FireCourse, userId: string, role: string) => {
+    if (role === 'ta') {
+        course.tas = [...course.tas, userId];
+    }
+    if (role === 'professor') {
+        course.professors = [...course.professors, userId];
+    }
+
+    return course;
+}
+
 exports.onQuestionCreate = functions.firestore
     .document('questions/{questionId}')
     .onCreate((snap) => {

--- a/src/components/types/fireData.d.ts
+++ b/src/components/types/fireData.d.ts
@@ -137,6 +137,11 @@ interface FireUser {
     roles: { readonly [courseId: string]: PrivilegedFireCourseRole | undefined };
 }
 
+interface FirePendingUser {
+    email: string;
+    roles: Record<string, role>;
+}
+
 interface FireQuestion {
     askerId: string;
     answererId: string;


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
This PR adds the second part of the ability to assign roles to users who do not exist in the database yet, which vastly simplifies the process of onboarding TAs and other professors for a course.

This PR adds the firebase function onUserCreate, which - upon the creation of a new Queue Me In user - checks the `pendingUsers` collection for a pending user with a matching email. If a `pendingUser` is found, the roles of the pendingUser document are copied over to the newly-created user, and each of the classes specified in the new roles will gain the newly-created user as that specified role. In addition, now that the user has been created, roles can be added to that user normally, so the user's entry in pendingUsers is deleted.

<!-- Add your summary here -->

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->

<!-- Briefly describe how you test you changes. -->

1. Create a new fake gmail account.
2. Add a new document in the pendingUsers collection, where the field `email` matches the full email address of the new fake gmail you created and the `roles` field is a map where each entry is a key equal to the document `id` of a course in QMI(-test) and the value is the role, either `ta` or `professor`. Keep this tab open.
3. On a new instance of Queue Me In in incognito mode, log into your new fake gmail account.
4. After a second (hopefully much, much shorter after the cloud function spools up after repeated users), you will gain the roles specified in pendingUsers.
5. Check the entry for your account in pendingUsers. It should have been deleted automatically.

Bug:
This can POTENTIALLY (although highly unlikely) break the 'new user page experience' for a user if they are assigned a `ta` or `professor` role to ALL of the available classes this semester. `Since only editing the course selection exits the user from the 'non-normal'-mode,` combined with the fact that none of the classes are selectable (since the user is a `ta` or `professor` of every available class, `some users will be stuck on the edit page (where isNormalEditMode = false) forever.`

The fix is as follows: if isNormalEdiintMode is false, if the user selects any of the courses (already checked), OR if the user is a `ta` or `professor` of any of the courses, the user should be able to save & exit editing mode.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
