### PR TITLE
fast-forward semester start

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
 export const CURRENT_SEMESTER = 'SP21';
 
-export const START_DATE = '2021-02-01'
+export const START_DATE = '2021-01-17'
 export const END_DATE = '2021-05-30'


### PR DESCRIPTION
Changes semester start to yesterday (Jan. 17) to allow interested folks to start using Queue Me In early.