### PR TITLE
Attempt to fix timezones in createSeries.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lodash": "^4.17.15",
     "mocha": "^8.2.1",
     "moment": "^2.22.2",
-    "moment-timezone": "^0.5.21",
+    "moment-timezone": "^0.5.32",
     "react": "^16.8.0",
     "react-datepicker": "1.3.0",
     "react-dates": "^18.2.2",

--- a/src/firebasefunctions.ts
+++ b/src/firebasefunctions.ts
@@ -167,7 +167,7 @@ export const createSeries = async (
                 batch.set(db.collection('sessions').doc(), derivedSession);
             }
         }
-        currentDate = datePlusWithDST(currentDate, 7 * 24 * 3600); // move 1 week forward.
+        currentDate = datePlusWithDST(currentDate, 7 * 24 * 3600 * 1000); // move 1 week forward.
     }
     await batch.commit();
 };

--- a/src/utilities/date.ts
+++ b/src/utilities/date.ts
@@ -5,7 +5,7 @@ export const datePlusWithDST = (date: Date, offsetInSecs: number): Date => {
 
     const futureOffset = utcOffsetOfDate(date, offsetInSecs)
 
-    const offsetDiffSecs = (futureOffset - currentOffset) * 3600;
+    const offsetDiffSecs = (futureOffset - currentOffset) * 60;
     return new Date(date.getTime() + offsetInSecs + offsetDiffSecs);
 };
 

--- a/src/utilities/date.ts
+++ b/src/utilities/date.ts
@@ -5,13 +5,13 @@ export const datePlusWithDST = (date: Date, offsetInSecs: number): Date => {
 
     const futureOffset = utcOffsetOfDate(date, offsetInSecs)
 
-    const offsetDiffSecs = (futureOffset - currentOffset) * 60;
+    const offsetDiffSecs = (futureOffset - currentOffset);
     return new Date(date.getTime() + offsetInSecs + offsetDiffSecs);
 };
 
 export const utcOffsetOfDate = (date: Date, offset = 0) => {
     const zone = moment.tz.zone('America/New_York')!;
-    return zone.offset((date.getTime() + offset)/1000);
+    return zone.utcOffset((date.getTime() + offset) * 60);
 }
 
 /** Gets time at the beginning of the day */

--- a/src/utilities/date.ts
+++ b/src/utilities/date.ts
@@ -1,11 +1,15 @@
-export const datePlus = (date: Date, offset: number): Date => new Date(date.getTime() + offset);
+export const datePlus = (date: Date, offset: number): Date => {
+    return new Date(date.getTime() + offset)
+};
 
+/** Gets time at the beginning of the day */
 export const normalizeDateToDateStart = (date: Date): Date => {
     const normalized = new Date(date);
     normalized.setHours(0, 0, 0, 0);
     return normalized;
 };
 
+/** Gets time at the beginning of the week */
 export const normalizeDateToWeekStart = (date: Date): Date => {
     const normalized = new Date(date);
     normalized.setHours(0, 0, 0, 0);

--- a/src/utilities/date.ts
+++ b/src/utilities/date.ts
@@ -1,6 +1,18 @@
-export const datePlus = (date: Date, offset: number): Date => {
-    return new Date(date.getTime() + offset)
+import moment from 'moment-timezone';
+
+export const datePlusWithDST = (date: Date, offsetInSecs: number): Date => {
+    let currentOffset = utcOffsetOfDate(date);
+
+    let futureOffset = utcOffsetOfDate(date, offsetInSecs)
+
+    let offsetDiffSecs = (futureOffset - currentOffset) * 3600;
+    return new Date(date.getTime() + offsetInSecs + offsetDiffSecs);
 };
+
+export const utcOffsetOfDate = (date: Date, offset: number = 0) => {
+    let zone = moment.tz.zone('America/New_York')!;
+    return zone.offset((date.getTime() + offset)/1000);
+}
 
 /** Gets time at the beginning of the day */
 export const normalizeDateToDateStart = (date: Date): Date => {

--- a/src/utilities/date.ts
+++ b/src/utilities/date.ts
@@ -1,16 +1,16 @@
 import moment from 'moment-timezone';
 
 export const datePlusWithDST = (date: Date, offsetInSecs: number): Date => {
-    let currentOffset = utcOffsetOfDate(date);
+    const currentOffset = utcOffsetOfDate(date);
 
-    let futureOffset = utcOffsetOfDate(date, offsetInSecs)
+    const futureOffset = utcOffsetOfDate(date, offsetInSecs)
 
-    let offsetDiffSecs = (futureOffset - currentOffset) * 3600;
+    const offsetDiffSecs = (futureOffset - currentOffset) * 3600;
     return new Date(date.getTime() + offsetInSecs + offsetDiffSecs);
 };
 
-export const utcOffsetOfDate = (date: Date, offset: number = 0) => {
-    let zone = moment.tz.zone('America/New_York')!;
+export const utcOffsetOfDate = (date: Date, offset = 0) => {
+    const zone = moment.tz.zone('America/New_York')!;
     return zone.offset((date.getTime() + offset)/1000);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11808,10 +11808,10 @@ mocha@^8.2.1:
     yargs-parser "13.1.2"
     yargs-unparser "2.0.0"
 
-moment-timezone@^0.5.21:
-  version "0.5.26"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.26.tgz#c0267ca09ae84631aa3dc33f65bedbe6e8e0d772"
-  integrity sha512-sFP4cgEKTCymBBKgoxZjYzlSovC20Y6J7y3nanDc5RoBIXKlZhoYwBoZGe3flwU6A372AcRwScH8KiwV6zjy1g==
+moment-timezone@^0.5.32:
+  version "0.5.32"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.32.tgz#db7677cc3cc680fd30303ebd90b0da1ca0dfecc2"
+  integrity sha512-Z8QNyuQHQAmWucp8Knmgei8YNo28aLjJq6Ma+jy1ZSpSk5nyfRT8xgUbSQvD2+2UajISfenndwvFuH3NGS+nvA==
   dependencies:
     moment ">= 2.9.0"
 


### PR DESCRIPTION
### Summary <!-- Required -->
Renames function `datePlus` to `datePlusWithOffset(date: Date, offsetInSecs: number)`. This function now considers the UTC offsets of `date` and `date + offsetInSecs` and adds the difference (expressed in minutes and multiplied by 60 to get seconds) to the initially calculated offset.

Introduces helper method `utcOffsetOfDate(date, offset = 0)` to calculate the UTC offset in minutes.

In `createSeries`, replaces `const currentDate` with `let` and calculates the next date with `currentDate = datePlusWithDST(currentDate, 7 * 24 * 3600 * 1000)`, which adjusts the next date with respect to daylight savings time.

**NOTE**
I'm not entirely sure if `getWeekOffsets` / `normalizeDateToWeekStart` / `normalizeDateToDateStart` correctly handle daylight savings time. Since they are raw offsets I'm inclined to say they are OK?

<!-- Provide a general summary of your changes in the Title above -->

<!-- Add your summary here -->

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->

<!-- Briefly describe how you test you changes. -->
Create a session with dates that straddle before & after DST clock offsets change.

Create a session before a DST clock change, with a start date AFTER the DST clock change.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
