### PR TITLE
Display student link to TAs in hybrid office hours

### DIFF
--- a/src/components/includes/AddQuestion.tsx
+++ b/src/components/includes/AddQuestion.tsx
@@ -150,10 +150,10 @@ class AddQuestion extends React.Component<Props, State> {
                 timeEntered: firebase.firestore.Timestamp.now()
             };
 
-            const location = 'building' in this.props.session ? {} : { location: this.state.location };
+            const location = this.state.location.length === 0 ? {} : { location: this.state.location };
             const upvotedUsers = this.props.session.modality === "review" ? {upvotedUsers: [auth.currentUser.uid]} : {}
 
-            const newQuestion: Omit<FireQuestion, 'questionId'> = {
+            const newQuestion: Omit<FireOHQuestion, 'questionId'> = {
                 ...newQuestionSlot,
                 ...location,
                 ...upvotedUsers,


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
Addresses issue #490. The link that students provide when joining the queue for a hybrid office hours session now gets displayed to TAs.  
<!-- Add your summary here -->

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->

<!-- Briefly describe how you test you changes. -->
Join a hybrid office hours session queue as a student. Sign in as a TA, and the link that you provided when joining the queue should be now visible.
### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
