### PR TITLE
Updated import for logo in TopBar and fixed styles for new aspect ratio

### DIFF
--- a/src/components/includes/TopBar.tsx
+++ b/src/components/includes/TopBar.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Icon } from 'semantic-ui-react';
 import { logOut } from '../../firebasefunctions';
-import Logo from '../../media/Logo.svg';
+import Logo from '../../media/QLogo2.svg';
 import CalendarHeader from './CalendarHeader';
 import ProfessorStudentToggle from './ProfessorStudentToggle';
 

--- a/src/styles/TopBar.scss
+++ b/src/styles/TopBar.scss
@@ -56,7 +56,7 @@
 
         .QMILogo {
             margin-bottom: 10px;
-            width: 50px;
+            width: 30px;
             margin-left: 46px;
         }
 


### PR DESCRIPTION
### Summary <!-- Required -->

Logo Updated

Updated the import statement within the TopBar.tsx file, and then changed the width styling within TopBar.scss because the aspect ratio of the previous navbar logo was 2:1 whereas this logo is 1:1. It is worth noting that this logo is thus slightly taller than the previous (~4px taller) and takes slightly more vertical space. This appears to have very little affect on the spacing of the other elements in the navbar, however.


### Test Plan <!-- Required -->

Changed window size, both width and height, and observed that expected behavior occurred with resizing (and TopBar disappearing at certain width). Navigated throughout the website to make sure there is no unexpected behavior with the logo.


### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
