### PR TITLE
Add missing transitions in add question state machine 

### DIFF
--- a/src/components/includes/AddQuestion.tsx
+++ b/src/components/includes/AddQuestion.tsx
@@ -69,11 +69,14 @@ const AddQuestion = (
 
     const handlePrimarySelected = (tag: FireTag | undefined): void => {
         if (selectedPrimary) {
+            setLocation('');
+            setQuestion('');
             if (selectedPrimary.tagId === tag?.tagId) {
                 setStage(10);
                 setSelectedPrimary(undefined);
                 setSelectedSecondary(undefined);
             } else {
+                setStage(20);
                 setSelectedPrimary(tag);
                 setSelectedSecondary(undefined);
             }
@@ -90,10 +93,13 @@ const AddQuestion = (
 
     const handleSecondarySelected = (tag: FireTag): void => {
         if (selectedSecondary) {
+            setLocation('');
+            setQuestion('');
             if (selectedSecondary.tagId === tag.tagId) {
                 setStage(20);
                 setSelectedSecondary(undefined);
             } else {
+                !('building' in session) ? setStage(40) : setStage(30);
                 setSelectedSecondary(tag);
             }
         } else if (!('building' in session)) {
@@ -263,7 +269,7 @@ const AddQuestion = (
                                 </div>
                                 : <p className="placeHolder text">Finish selecting tags...</p>}
                         </div>
-                        <hr /></>}
+                            <hr /></>}
                         <div className="tagsMiniContainer">
                             <p className="header">
                                 {'Question '}

--- a/src/components/includes/AddQuestion.tsx
+++ b/src/components/includes/AddQuestion.tsx
@@ -269,7 +269,7 @@ const AddQuestion = (
                                 </div>
                                 : <p className="placeHolder text">Finish selecting tags...</p>}
                         </div>
-                            <hr /></>}
+                        <hr /></>}
                         <div className="tagsMiniContainer">
                             <p className="header">
                                 {'Question '}


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->

<!-- Add your summary here -->
There were a few missing transitions in the add question state machine that were causing the following (and similar) bug: 
- select a primary tag 
- select a secondary tag 
- reselect a primary tag (which will clear the secondary tag)
- you can still proceed to enter a location and question and the join button seems clickable

The state machine is outlined [here](https://github.com/cornell-dti/office-hours/wiki/AddQuestion-Component#state-machine-outline) 
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->

<!-- Briefly describe how you test you changes. -->
When you unselect a primary tag, secondary tag, clear location, or question, the join the queue card goes back to the step that you changed (everything else gets cleared)
### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
