### PR TITLE
Added loading for new users during cloud function latency

### DIFF
--- a/src/components/pages/CourseEditView.tsx
+++ b/src/components/pages/CourseEditView.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { Loader } from 'semantic-ui-react';
 import CourseSelection from '../includes/CourseSelection';
-import { useMyUser, useAllCourses } from '../../firehooks';
+import { useMyUser, useAllCourses, usePendingUser } from '../../firehooks';
 
 export default () => {
     const user = useMyUser();
     const allCourses = useAllCourses();
-    if (user === undefined || allCourses.length === 0) {
+    const pendingUser = usePendingUser();
+    console.log(pendingUser)
+    if (user === undefined || allCourses.length === 0 || pendingUser?.email) {
         // Clearly not all data have been loaded.
         return <Loader active={true} content="Loading" />;
     }

--- a/src/components/pages/CourseEditView.tsx
+++ b/src/components/pages/CourseEditView.tsx
@@ -7,7 +7,6 @@ export default () => {
     const user = useMyUser();
     const allCourses = useAllCourses();
     const pendingUser = usePendingUser();
-    console.log(pendingUser)
     if (user === undefined || allCourses.length === 0 || pendingUser?.email) {
         // Clearly not all data have been loaded.
         return <Loader active={true} content="Loading" />;

--- a/src/components/pages/CourseSelectionView.tsx
+++ b/src/components/pages/CourseSelectionView.tsx
@@ -6,6 +6,7 @@ import { useMyUser, useAllCourses } from '../../firehooks';
 export default () => {
     const user = useMyUser();
     const allCourses = useAllCourses();
+
     if (user === undefined || allCourses.length === 0) {
         // Clearly not all data have been loaded.
         return <Loader active={true} content="Loading" />;

--- a/src/firehooks.ts
+++ b/src/firehooks.ts
@@ -104,6 +104,15 @@ const myUserObservable = loggedIn$.pipe(
 export const myUserSingletonObservable = new SingletonObservable(undefined, myUserObservable);
 export const useMyUser: () => FireUser | undefined = createUseSingletonObservableHook(myUserSingletonObservable);
 
+const needsPromotionObservable = loggedIn$.pipe(
+    switchMap(u =>
+        docData(firestore.doc('pendingUsers/' + u.email)) as Observable<FirePendingUser>
+    )
+)
+
+export const needsPromotionSingletonObservable = new SingletonObservable(undefined, needsPromotionObservable);
+export const usePendingUser : () => FirePendingUser | undefined  = createUseSingletonObservableHook(needsPromotionSingletonObservable);
+
 const allCoursesObservable: Observable<readonly FireCourse[]> = loggedIn$.pipe(
     switchMap(() => collectionData<FireCourse>(firestore.collection('courses'), 'courseId'))
 );

--- a/src/firehooks.ts
+++ b/src/firehooks.ts
@@ -111,7 +111,9 @@ const needsPromotionObservable = loggedIn$.pipe(
 )
 
 export const needsPromotionSingletonObservable = new SingletonObservable(undefined, needsPromotionObservable);
-export const usePendingUser : () => FirePendingUser | undefined  = createUseSingletonObservableHook(needsPromotionSingletonObservable);
+
+export const usePendingUser: () => FirePendingUser | undefined  = 
+    createUseSingletonObservableHook(needsPromotionSingletonObservable);
 
 const allCoursesObservable: Observable<readonly FireCourse[]> = loggedIn$.pipe(
     switchMap(() => collectionData<FireCourse>(firestore.collection('courses'), 'courseId'))


### PR DESCRIPTION
### Summary <!-- Required -->

Added a new observable hook for a pendingUser document associated with the current user, so that when a user first logs in, it verifies whether the cloud function will run.

If the user has no associated pendingUser document, the course selection view loads as normal. If the user has an associated pendingUser document, the <Loading /> sematic ui React component notifies the user that there is logic running such that they cannot access the page. 

### Test Plan <!-- Required -->

Tested loading with a new user both with and without a pendingUser document associated.  Also verified that the other course selection (non-editing view) is unaffected. 

### Notes <!-- Optional -->

Possible future development may involve a new component for this specific case that is less ambiguous. The loading screen currently is just the loading circle, while perhaps a custom message may alleviate new user concerns.

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
