### PR TITLE
Fixing issue #497, refactoring AdminView into multiple components, and adding some styles to AdminView

### DIFF
--- a/src/components/includes/AdminCourseCard.tsx
+++ b/src/components/includes/AdminCourseCard.tsx
@@ -1,0 +1,27 @@
+import React, {useState} from "react";
+import AdminReadOnlyCourseCard from "./AdminReadOnlyCourseCard";
+import AdminEditableCourseCard from "./AdminEditableCourseCard";
+import ProfessorRolesTable from '../includes/ProfessorRolesTable';
+import {Card} from "@material-ui/core";
+
+const AdminCourseCard = ({ course }: { readonly course: FireCourse }) => {
+  const [isEditingMode, setIsEditingMode] = useState(false);
+  const [showRolesTable, setShowRolesTable] = useState(false);
+  return (
+      <Card className="course">
+          {!isEditingMode && <AdminReadOnlyCourseCard course={course} />}
+          {isEditingMode && <AdminEditableCourseCard course={course} />}
+          <div>
+              <button type="button" className="editing-button" onClick={() => setIsEditingMode(prev => !prev)}>
+                  To {isEditingMode ? 'Read Only' : 'Editing'} Mode
+              </button>
+              <button type="button" className="roles-button" onClick={() => setShowRolesTable(prev => !prev)}>
+                  {showRolesTable ? 'Hide' : 'Show'} Roles Table
+              </button>
+          </div>
+          {showRolesTable && <ProfessorRolesTable courseId={course.courseId} isAdminView={true}/>}
+      </Card>
+  );
+};
+
+export default AdminCourseCard;

--- a/src/components/includes/AdminCourseCard.tsx
+++ b/src/components/includes/AdminCourseCard.tsx
@@ -1,27 +1,29 @@
 import React, {useState} from "react";
-import AdminReadOnlyCourseCard from "./AdminReadOnlyCourseCard";
-import AdminEditableCourseCard from "./AdminEditableCourseCard";
-import ProfessorRolesTable from '../includes/ProfessorRolesTable';
 import {Card} from "@material-ui/core";
 
+import AdminReadOnlyCourseCard from "./AdminReadOnlyCourseCard";
+import AdminEditableCourseCard from "./AdminEditableCourseCard";
+import ProfessorRolesTable from './ProfessorRolesTable';
+
+
 const AdminCourseCard = ({ course }: { readonly course: FireCourse }) => {
-  const [isEditingMode, setIsEditingMode] = useState(false);
-  const [showRolesTable, setShowRolesTable] = useState(false);
-  return (
-      <Card className="course">
-          {!isEditingMode && <AdminReadOnlyCourseCard course={course} />}
-          {isEditingMode && <AdminEditableCourseCard course={course} />}
-          <div>
-              <button type="button" className="editing-button" onClick={() => setIsEditingMode(prev => !prev)}>
-                  To {isEditingMode ? 'Read Only' : 'Editing'} Mode
-              </button>
-              <button type="button" className="roles-button" onClick={() => setShowRolesTable(prev => !prev)}>
-                  {showRolesTable ? 'Hide' : 'Show'} Roles Table
-              </button>
-          </div>
-          {showRolesTable && <ProfessorRolesTable courseId={course.courseId} isAdminView={true}/>}
-      </Card>
-  );
+    const [isEditingMode, setIsEditingMode] = useState(false);
+    const [showRolesTable, setShowRolesTable] = useState(false);
+    return (
+        <Card className="course">
+            {!isEditingMode && <AdminReadOnlyCourseCard course={course} />}
+            {isEditingMode && <AdminEditableCourseCard course={course} />}
+            <div>
+                <button type="button" className="editing-button" onClick={() => setIsEditingMode(prev => !prev)}>
+                    To {isEditingMode ? 'Read Only' : 'Editing'} Mode
+                </button>
+                <button type="button" className="roles-button" onClick={() => setShowRolesTable(prev => !prev)}>
+                    {showRolesTable ? 'Hide' : 'Show'} Roles Table
+                </button>
+            </div>
+            {showRolesTable && <ProfessorRolesTable courseId={course.courseId} isAdminView={true}/>}
+        </Card>
+    );
 };
 
 export default AdminCourseCard;

--- a/src/components/includes/AdminCourseCreator.tsx
+++ b/src/components/includes/AdminCourseCreator.tsx
@@ -1,0 +1,84 @@
+import React, {useState} from "react";
+import firebase from 'firebase/app';
+
+import { firestore } from '../../firebase';
+import { CURRENT_SEMESTER, START_DATE, END_DATE } from '../../constants';
+
+const startDate = new Date(START_DATE);
+const endDate = new Date(END_DATE);
+const currentTerm = CURRENT_SEMESTER.substring(0, 2);
+const currentYear = CURRENT_SEMESTER.substring(2, 4);
+
+const AdminCourseCreator = ({ onSubmit }: { readonly onSubmit: () => void }) => {
+    const [courseId, setCourseId] = useState('');
+    const [name, setName] = useState('');
+    const [code, setCode] = useState('');
+    const [semester, setSemester] = useState(CURRENT_SEMESTER);
+    const [year, setYear] = useState(currentTerm);
+    const [term, setTerm] = useState(currentYear);
+
+    const disabled = courseId.trim().length === 0
+        || name.trim().length === 0
+        || code.trim().length === 0
+        || semester.trim().length === 0
+        || year.trim().length === 0
+        || term.trim().length === 0;
+
+    const onSave = () => {
+        const course: Omit<FireCourse, 'courseId'> = {
+            name,
+            code,
+            semester,
+            year,
+            term,
+            queueOpenInterval: 30,
+            charLimit: 140,
+            startDate: firebase.firestore.Timestamp.fromDate(startDate),
+            endDate: firebase.firestore.Timestamp.fromDate(endDate),
+            professors: [],
+            tas: []
+        };
+        firestore.collection('courses').doc(courseId).set(course).then(onSubmit);
+    };
+
+    return (
+        <div className="course">
+            <h2>Create New Course</h2>
+            <div className="course-section">
+                <h3>Course Id</h3>
+                <input type="text" value={courseId} onChange={e => setCourseId(e.currentTarget.value)} />
+            </div>
+            <div className="course-section">
+                <h3>Course Name</h3>
+                <input type="text" value={name} onChange={e => setName(e.currentTarget.value)} />
+            </div>
+            <div className="course-section">
+                <h3>Course Code</h3>
+                <input type="text" value={code} onChange={e => setCode(e.currentTarget.value)} />
+            </div>
+            <div className="course-section">
+                <h3>Semester</h3>
+                <input type="text" value={semester} onChange={e => setSemester(e.currentTarget.value)} />
+            </div>
+            <div className="course-section">
+                <h3>Year</h3>
+                <input type="text" value={year} onChange={e => setYear(e.currentTarget.value)} />
+            </div>
+            <div className="course-section">
+                <h3>Term</h3>
+                <input type="text" value={term} onChange={e => setTerm(e.currentTarget.value)} />
+            </div>
+            <div className="course-section">
+                <h3>Start Date</h3>
+                <div>{startDate.toLocaleDateString()}</div>
+            </div>
+            <div className="course-section">
+                <h3>End Date</h3>
+                <div>{endDate.toLocaleDateString()}</div>
+            </div>
+            <button type="button" disabled={disabled} onClick={onSave}>Save</button>
+        </div>
+    );
+};
+
+export default AdminCourseCreator;

--- a/src/components/includes/AdminEditableCourseCard.tsx
+++ b/src/components/includes/AdminEditableCourseCard.tsx
@@ -1,0 +1,47 @@
+import React, {useState} from "react";
+import { firestore } from '../../firebase';
+
+const AdminEditableCourseCard = ({ course }: { readonly course: FireCourse }) => {
+  const [name, setName] = useState(course.name);
+  const [code, setCode] = useState(course.code);
+  const [semester, setSemester] = useState(course.semester);
+  const [year, setYear] = useState(course.year);
+  const [term, setTerm] = useState(course.term);
+
+  const onSave = () => {
+      const update: Partial<FireCourse> = { name, code, semester, year, term };
+      firestore.collection('courses').doc(course.courseId).update(update);
+  };
+
+  return (
+      <div>
+          <div className="course-section">
+              <h3>Course ID</h3>
+              <div>{course.courseId}</div>
+          </div>
+          <div className="course-section">
+              <h3>Course Name</h3>
+              <input type="text" value={name} onChange={e => setName(e.currentTarget.value)} />
+          </div>
+          <div className="course-section">
+              <h3>Course Code</h3>
+              <input type="text" value={code} onChange={e => setCode(e.currentTarget.value)} />
+          </div>
+          <div className="course-section">
+              <h3>Semester</h3>
+              <input type="text" value={semester} onChange={e => setSemester(e.currentTarget.value)} />
+          </div>
+          <div className="course-section">
+              <h3>Year</h3>
+              <input type="text" value={year} onChange={e => setYear(e.currentTarget.value)} />
+          </div>
+          <div className="course-section">
+              <h3>Term</h3>
+              <input type="text" value={term} onChange={e => setTerm(e.currentTarget.value)} />
+          </div>
+          <button type="button" onClick={onSave}>Save</button>
+      </div>
+  );
+};
+
+export default AdminEditableCourseCard;

--- a/src/components/includes/AdminEditableCourseCard.tsx
+++ b/src/components/includes/AdminEditableCourseCard.tsx
@@ -2,46 +2,46 @@ import React, {useState} from "react";
 import { firestore } from '../../firebase';
 
 const AdminEditableCourseCard = ({ course }: { readonly course: FireCourse }) => {
-  const [name, setName] = useState(course.name);
-  const [code, setCode] = useState(course.code);
-  const [semester, setSemester] = useState(course.semester);
-  const [year, setYear] = useState(course.year);
-  const [term, setTerm] = useState(course.term);
+    const [name, setName] = useState(course.name);
+    const [code, setCode] = useState(course.code);
+    const [semester, setSemester] = useState(course.semester);
+    const [year, setYear] = useState(course.year);
+    const [term, setTerm] = useState(course.term);
 
-  const onSave = () => {
-      const update: Partial<FireCourse> = { name, code, semester, year, term };
-      firestore.collection('courses').doc(course.courseId).update(update);
-  };
+    const onSave = () => {
+        const update: Partial<FireCourse> = { name, code, semester, year, term };
+        firestore.collection('courses').doc(course.courseId).update(update);
+    };
 
-  return (
-      <div>
-          <div className="course-section">
-              <h3>Course ID</h3>
-              <div>{course.courseId}</div>
-          </div>
-          <div className="course-section">
-              <h3>Course Name</h3>
-              <input type="text" value={name} onChange={e => setName(e.currentTarget.value)} />
-          </div>
-          <div className="course-section">
-              <h3>Course Code</h3>
-              <input type="text" value={code} onChange={e => setCode(e.currentTarget.value)} />
-          </div>
-          <div className="course-section">
-              <h3>Semester</h3>
-              <input type="text" value={semester} onChange={e => setSemester(e.currentTarget.value)} />
-          </div>
-          <div className="course-section">
-              <h3>Year</h3>
-              <input type="text" value={year} onChange={e => setYear(e.currentTarget.value)} />
-          </div>
-          <div className="course-section">
-              <h3>Term</h3>
-              <input type="text" value={term} onChange={e => setTerm(e.currentTarget.value)} />
-          </div>
-          <button type="button" onClick={onSave}>Save</button>
-      </div>
-  );
+    return (
+        <div>
+            <div className="course-section">
+                <h3>Course ID</h3>
+                <div>{course.courseId}</div>
+            </div>
+            <div className="course-section">
+                <h3>Course Name</h3>
+                <input type="text" value={name} onChange={e => setName(e.currentTarget.value)} />
+            </div>
+            <div className="course-section">
+                <h3>Course Code</h3>
+                <input type="text" value={code} onChange={e => setCode(e.currentTarget.value)} />
+            </div>
+            <div className="course-section">
+                <h3>Semester</h3>
+                <input type="text" value={semester} onChange={e => setSemester(e.currentTarget.value)} />
+            </div>
+            <div className="course-section">
+                <h3>Year</h3>
+                <input type="text" value={year} onChange={e => setYear(e.currentTarget.value)} />
+            </div>
+            <div className="course-section">
+                <h3>Term</h3>
+                <input type="text" value={term} onChange={e => setTerm(e.currentTarget.value)} />
+            </div>
+            <button type="button" onClick={onSave}>Save</button>
+        </div>
+    );
 };
 
 export default AdminEditableCourseCard;

--- a/src/components/includes/AdminReadOnlyCourseCard.tsx
+++ b/src/components/includes/AdminReadOnlyCourseCard.tsx
@@ -2,58 +2,58 @@ import React from "react";
 import { useCourseProfessorMap, useCourseTAMap } from '../../firehooks';
 
 const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) => {
-  const professorMap = useCourseProfessorMap(course);
-  const taMap = useCourseTAMap(course);
+    const professorMap = useCourseProfessorMap(course);
+    const taMap = useCourseTAMap(course);
 
-  return (
-      <div>
-          <div className="course-section">
-              <h3>{course.courseId} ({course.code}: {course.name})</h3>
-              <div>Semester: {course.semester}, year: {course.year}, term: {course.term}</div>
-          </div>
-          <div className="course-section">
-              <h3>Settings: </h3>
-              <div>Queue Open Interval: {course.queueOpenInterval}</div>
-              <div>Char Limit: {course.charLimit}</div>
-              <div>Start Date: {course.startDate.toDate().toLocaleDateString()}</div>
-              <div>End Date: {course.endDate.toDate().toLocaleDateString()}</div>
-          </div>
-          <div className="course-section">
-              <h3>Professors</h3>
-              {course.professors.length === 0 && <div>None</div>}
-              <ul>
-                  {course.professors.map(id => {
-                      const professor = professorMap[id];
-                      if (professor == null) {
-                          return null;
-                      }
-                      return (
-                          <li key={id}>
-                              {professor.firstName} {professor.lastName} ({professor.email})
-                          </li>
-                      );
-                  })}
-              </ul>
-          </div>
-          <div className="course-section">
-              <h3>TAs</h3>
-              {course.tas.length === 0 && <div>None</div>}
-              <ul>
-                  {course.tas.map(id => {
-                      const ta = taMap[id];
-                      if (ta == null) {
-                          return null;
-                      }
-                      return (
-                          <li key={id}>
-                              {ta.firstName} {ta.lastName} ({ta.email})
-                          </li>
-                      );
-                  })}
-              </ul>
-          </div>
-      </div>
-  );
+    return (
+        <div>
+            <div className="course-section">
+                <h3>{course.courseId} ({course.code}: {course.name})</h3>
+                <div>Semester: {course.semester}, year: {course.year}, term: {course.term}</div>
+            </div>
+            <div className="course-section">
+                <h3>Settings: </h3>
+                <div>Queue Open Interval: {course.queueOpenInterval}</div>
+                <div>Char Limit: {course.charLimit}</div>
+                <div>Start Date: {course.startDate.toDate().toLocaleDateString()}</div>
+                <div>End Date: {course.endDate.toDate().toLocaleDateString()}</div>
+            </div>
+            <div className="course-section">
+                <h3>Professors</h3>
+                {course.professors.length === 0 && <div>None</div>}
+                <ul>
+                    {course.professors.map(id => {
+                        const professor = professorMap[id];
+                        if (professor == null) {
+                            return null;
+                        }
+                        return (
+                            <li key={id}>
+                                {professor.firstName} {professor.lastName} ({professor.email})
+                            </li>
+                        );
+                    })}
+                </ul>
+            </div>
+            <div className="course-section">
+                <h3>TAs</h3>
+                {course.tas.length === 0 && <div>None</div>}
+                <ul>
+                    {course.tas.map(id => {
+                        const ta = taMap[id];
+                        if (ta == null) {
+                            return null;
+                        }
+                        return (
+                            <li key={id}>
+                                {ta.firstName} {ta.lastName} ({ta.email})
+                            </li>
+                        );
+                    })}
+                </ul>
+            </div>
+        </div>
+    );
 };
 
 export default AdminReadOnlyCourseCard;

--- a/src/components/includes/AdminReadOnlyCourseCard.tsx
+++ b/src/components/includes/AdminReadOnlyCourseCard.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { useCourseProfessorMap, useCourseTAMap } from '../../firehooks';
+
+const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) => {
+  const professorMap = useCourseProfessorMap(course);
+  const taMap = useCourseTAMap(course);
+
+  return (
+      <div>
+          <div className="course-section">
+              <h3>{course.courseId} ({course.code}: {course.name})</h3>
+              <div>Semester: {course.semester}, year: {course.year}, term: {course.term}</div>
+          </div>
+          <div className="course-section">
+              <h3>Settings: </h3>
+              <div>Queue Open Interval: {course.queueOpenInterval}</div>
+              <div>Char Limit: {course.charLimit}</div>
+              <div>Start Date: {course.startDate.toDate().toLocaleDateString()}</div>
+              <div>End Date: {course.endDate.toDate().toLocaleDateString()}</div>
+          </div>
+          <div className="course-section">
+              <h3>Professors</h3>
+              {course.professors.length === 0 && <div>None</div>}
+              <ul>
+                  {course.professors.map(id => {
+                      const professor = professorMap[id];
+                      if (professor == null) {
+                          return null;
+                      }
+                      return (
+                          <li key={id}>
+                              {professor.firstName} {professor.lastName} ({professor.email})
+                          </li>
+                      );
+                  })}
+              </ul>
+          </div>
+          <div className="course-section">
+              <h3>TAs</h3>
+              {course.tas.length === 0 && <div>None</div>}
+              <ul>
+                  {course.tas.map(id => {
+                      const ta = taMap[id];
+                      if (ta == null) {
+                          return null;
+                      }
+                      return (
+                          <li key={id}>
+                              {ta.firstName} {ta.lastName} ({ta.email})
+                          </li>
+                      );
+                  })}
+              </ul>
+          </div>
+      </div>
+  );
+};
+
+export default AdminReadOnlyCourseCard;

--- a/src/components/includes/ProfessorRolesTable.tsx
+++ b/src/components/includes/ProfessorRolesTable.tsx
@@ -75,61 +75,61 @@ export default ({ courseId, isAdminView }: { courseId: string; isAdminView: bool
     const importButton = () => {
         return (
             <div className="import-buttons">
-                    <button type="button" onClick={importProfessorsButtonOnClick}>Import Professors</button>
-                    <button type="button" onClick={importTAButtonOnClick}>Import TAs</button>
+                <button type="button" onClick={importProfessorsButtonOnClick}>Import Professors</button>
+                <button type="button" onClick={importTAButtonOnClick}>Import TAs</button>
             </div>
         )
     };
 
     return (
         <div className="rolesTable">
-        {isAdminView && importButton()}
-        <Table sortable={true} celled={true} fixed={true}>
-            <Table.Header>
-                <Table.Row>
-                    <Table.HeaderCell
-                        sorted={column === 'firstName' ? direction : undefined}
-                        onClick={handleSort('firstName')}
-                    >
-                        First Name
-                    </Table.HeaderCell>
-                    <Table.HeaderCell
-                        sorted={column === 'lastName' ? direction : undefined}
-                        onClick={handleSort('lastName')}
-                    >
-                        Last Name
-                    </Table.HeaderCell>
-                    <Table.HeaderCell
-                        sorted={column === 'email' ? direction : undefined}
-                        onClick={handleSort('email')}
-                    >
-                        Email
-                    </Table.HeaderCell>
-                    <Table.HeaderCell
-                        sorted={column === 'role' ? direction : undefined}
-                        onClick={handleSort('role')}
-                    >
-                        Role
-                    </Table.HeaderCell>
-                </Table.Row>
-            </Table.Header>
-            <Table.Body>
-                {course && sortedCourseUsers.map(u => (
-                    <Table.Row key={u.userId}>
-                        <Table.Cell>{u.firstName}</Table.Cell>
-                        <Table.Cell>{u.lastName}</Table.Cell>
-                        <Table.Cell>{u.email}</Table.Cell>
-                        <Table.Cell textAlign="right" className="dropdownCell">
-                            <RoleDropdown
-                                user={u}
-                                course={course}
-                                disabled={u.email === self?.email}
-                            />
-                        </Table.Cell>
+            {isAdminView && importButton()}
+            <Table sortable={true} celled={true} fixed={true}>
+                <Table.Header>
+                    <Table.Row>
+                        <Table.HeaderCell
+                            sorted={column === 'firstName' ? direction : undefined}
+                            onClick={handleSort('firstName')}
+                        >
+                            First Name
+                        </Table.HeaderCell>
+                        <Table.HeaderCell
+                            sorted={column === 'lastName' ? direction : undefined}
+                            onClick={handleSort('lastName')}
+                        >
+                            Last Name
+                        </Table.HeaderCell>
+                        <Table.HeaderCell
+                            sorted={column === 'email' ? direction : undefined}
+                            onClick={handleSort('email')}
+                        >
+                            Email
+                        </Table.HeaderCell>
+                        <Table.HeaderCell
+                            sorted={column === 'role' ? direction : undefined}
+                            onClick={handleSort('role')}
+                        >
+                            Role
+                        </Table.HeaderCell>
                     </Table.Row>
-                ))}
-            </Table.Body>
-        </Table>
+                </Table.Header>
+                <Table.Body>
+                    {course && sortedCourseUsers.map(u => (
+                        <Table.Row key={u.userId}>
+                            <Table.Cell>{u.firstName}</Table.Cell>
+                            <Table.Cell>{u.lastName}</Table.Cell>
+                            <Table.Cell>{u.email}</Table.Cell>
+                            <Table.Cell textAlign="right" className="dropdownCell">
+                                <RoleDropdown
+                                    user={u}
+                                    course={course}
+                                    disabled={u.email === self?.email}
+                                />
+                            </Table.Cell>
+                        </Table.Row>
+                    ))}
+                </Table.Body>
+            </Table>
         </div>
     );
 };

--- a/src/components/includes/ProfessorRolesTable.tsx
+++ b/src/components/includes/ProfessorRolesTable.tsx
@@ -74,19 +74,17 @@ export default ({ courseId, isAdminView }: { courseId: string; isAdminView: bool
 
     const importButton = () => {
         return (
-            <Table.Row>
-                <Table.Cell>
+            <div className="import-buttons">
                     <button type="button" onClick={importProfessorsButtonOnClick}>Import Professors</button>
-                </Table.Cell>
-                <Table.Cell>
                     <button type="button" onClick={importTAButtonOnClick}>Import TAs</button>
-                </Table.Cell> 
-            </Table.Row>
+            </div>
         )
     };
 
     return (
-        <Table sortable={true} celled={true} fixed={true} className="rolesTable">
+        <div className="rolesTable">
+        {isAdminView && importButton()}
+        <Table sortable={true} celled={true} fixed={true}>
             <Table.Header>
                 <Table.Row>
                     <Table.HeaderCell
@@ -116,9 +114,6 @@ export default ({ courseId, isAdminView }: { courseId: string; isAdminView: bool
                 </Table.Row>
             </Table.Header>
             <Table.Body>
-                <Table.Row>
-                    {isAdminView && importButton()}
-                </Table.Row>
                 {course && sortedCourseUsers.map(u => (
                     <Table.Row key={u.userId}>
                         <Table.Cell>{u.firstName}</Table.Cell>
@@ -135,5 +130,6 @@ export default ({ courseId, isAdminView }: { courseId: string; isAdminView: bool
                 ))}
             </Table.Body>
         </Table>
+        </div>
     );
 };

--- a/src/components/includes/TopBar.tsx
+++ b/src/components/includes/TopBar.tsx
@@ -31,7 +31,8 @@ const TopBar = (props: {
                     <div className="viewToggles">
                         <CalendarHeader
                             currentCourseCode={(props.course && props.course.code) || 'Courses'}
-                            role={props.user && props.course && (props.user.roles[props.course.courseId] || 'student' || props.admin)}
+                            role={props.user && props.course 
+                                    && (props.user.roles[props.course.courseId] || 'student' || props.admin)}
                         />
                         {props.role === 'professor' && 
                             <ProfessorStudentToggle

--- a/src/components/includes/TopBar.tsx
+++ b/src/components/includes/TopBar.tsx
@@ -15,6 +15,7 @@ const TopBar = (props: {
     // controls where "switch view" goes
     context: string;
     course?: FireCourse;
+    admin?: boolean;
 }) => {
     const [showMenu, setShowMenu] = useState(false);
     const [image, setImage] = useState(props.user ? props.user.photoUrl : '/placeholder.png');
@@ -30,7 +31,7 @@ const TopBar = (props: {
                     <div className="viewToggles">
                         <CalendarHeader
                             currentCourseCode={(props.course && props.course.code) || 'Courses'}
-                            role={props.user && props.course && (props.user.roles[props.course.courseId] || 'student')}
+                            role={props.user && props.course && (props.user.roles[props.course.courseId] || 'student' || props.admin)}
                         />
                         {props.role === 'professor' && 
                             <ProfessorStudentToggle

--- a/src/components/pages/AdminView.tsx
+++ b/src/components/pages/AdminView.tsx
@@ -36,13 +36,17 @@ const AdminView = () => {
             {inCreationMode && <AdminCourseCreator onSubmit={() => setInCreationMode(false)} />}
 
             {!inCreationMode &&
-                <button type="button" className="create-course" onClick={() => setInCreationMode(true)}>Create New Course</button>}
+                <button 
+                    type="button" 
+                    className="create-course" 
+                    onClick={() => setInCreationMode(true)}
+                >Create New Course</button>}
 
             <h2>Archived Courses</h2>
             <div className="course-container">
                 <Grid container direction="row" alignItems={'stretch'} spacing={3}>
                     {courses.filter(course => course.semester !== CURRENT_SEMESTER).map(course => (
-                        <Grid item xl = {3} lg={4} md={6} xs={12}>
+                        <Grid item xl={3} lg={4} md={6} xs={12}>
                             <AdminCourseCard key={course.courseId} course={course} />
                         </Grid>
                     ))}
@@ -51,7 +55,7 @@ const AdminView = () => {
             {!inCreationMode &&
                 <button 
                     type="button" 
-                    className="create-course" 
+                    className="create-course-btn" 
                     onClick={() => setInCreationMode(true)}
                 >Create New Course</button>}
         </div>

--- a/src/components/pages/AdminView.tsx
+++ b/src/components/pages/AdminView.tsx
@@ -1,205 +1,12 @@
 import React, { useState } from 'react';
-import firebase from 'firebase/app';
+import {Grid} from '@material-ui/core'
 
-import { useAllCourses, useCourseProfessorMap, useCourseTAMap } from '../../firehooks';
-import { firestore } from '../../firebase';
-import ProfessorRolesTable from '../includes/ProfessorRolesTable';
-import { CURRENT_SEMESTER, START_DATE, END_DATE } from '../../constants';
+import TopBar from '../includes/TopBar';
+import AdminCourseCard from "../includes/AdminCourseCard"
+import AdminCourseCreator from "../includes/AdminCourseCreator"
+import { useAllCourses, useMyUser } from '../../firehooks';
+import { CURRENT_SEMESTER } from '../../constants';
 
-const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) => {
-    const professorMap = useCourseProfessorMap(course);
-    const taMap = useCourseTAMap(course);
-
-    return (
-        <div>
-            <div className="course-section">
-                <h3>{course.courseId} ({course.code}: {course.name})</h3>
-                <div>Semester: {course.semester}, year: {course.year}, term: {course.term}</div>
-            </div>
-            <div className="course-section">
-                <h3>Settings: </h3>
-                <div>Queue Open Interval{course.queueOpenInterval}</div>
-                <div>Char Limit: {course.charLimit}</div>
-                <div>Start Date: {course.startDate.toDate().toLocaleDateString()}</div>
-                <div>End Date: {course.endDate.toDate().toLocaleDateString()}</div>
-            </div>
-            <div className="course-section">
-                <h3>Professors</h3>
-                {course.professors.length === 0 && <div>None</div>}
-                <ul>
-                    {course.professors.map(id => {
-                        const professor = professorMap[id];
-                        if (professor == null) {
-                            return null;
-                        }
-                        return (
-                            <li key={id}>
-                                {professor.firstName} {professor.lastName} ({professor.email})
-                            </li>
-                        );
-                    })}
-                </ul>
-            </div>
-            <div className="course-section">
-                <h3>TAs</h3>
-                {course.tas.length === 0 && <div>None</div>}
-                <ul>
-                    {course.tas.map(id => {
-                        const ta = taMap[id];
-                        if (ta == null) {
-                            return null;
-                        }
-                        return (
-                            <li key={id}>
-                                {ta.firstName} {ta.lastName} ({ta.email})
-                            </li>
-                        );
-                    })}
-                </ul>
-            </div>
-        </div>
-    );
-};
-
-const AdminEditableCourseCard = ({ course }: { readonly course: FireCourse }) => {
-    const [name, setName] = useState(course.name);
-    const [code, setCode] = useState(course.code);
-    const [semester, setSemester] = useState(course.semester);
-    const [year, setYear] = useState(course.year);
-    const [term, setTerm] = useState(course.term);
-
-    const onSave = () => {
-        const update: Partial<FireCourse> = { name, code, semester, year, term };
-        firestore.collection('courses').doc(course.courseId).update(update);
-    };
-
-    return (
-        <div>
-            <div className="course-section">
-                <h3>Course ID</h3>
-                <div>{course.courseId}</div>
-            </div>
-            <div className="course-section">
-                <h3>Course Name</h3>
-                <input type="text" value={name} onChange={e => setName(e.currentTarget.value)} />
-            </div>
-            <div className="course-section">
-                <h3>Course Code</h3>
-                <input type="text" value={code} onChange={e => setCode(e.currentTarget.value)} />
-            </div>
-            <div className="course-section">
-                <h3>Semester</h3>
-                <input type="text" value={semester} onChange={e => setSemester(e.currentTarget.value)} />
-            </div>
-            <div className="course-section">
-                <h3>Year</h3>
-                <input type="text" value={year} onChange={e => setYear(e.currentTarget.value)} />
-            </div>
-            <div className="course-section">
-                <h3>Term</h3>
-                <input type="text" value={term} onChange={e => setTerm(e.currentTarget.value)} />
-            </div>
-            <button type="button" onClick={onSave}>Save</button>
-        </div>
-    );
-};
-
-const AdminCourseCard = ({ course }: { readonly course: FireCourse }) => {
-    const [isEditingMode, setIsEditingMode] = useState(false);
-    const [showRolesTable, setShowRolesTable] = useState(false);
-    return (
-        <div className="course">
-            {!isEditingMode && <AdminReadOnlyCourseCard course={course} />}
-            {isEditingMode && <AdminEditableCourseCard course={course} />}
-            <div>
-                <button type="button" onClick={() => setIsEditingMode(prev => !prev)}>
-                    To {isEditingMode ? 'Read Only' : 'Editing'} Mode
-                </button>
-                <button type="button" onClick={() => setShowRolesTable(prev => !prev)}>
-                    {showRolesTable ? 'Hide' : 'Show'} Roles Table
-                </button>
-            </div>
-            {showRolesTable && <ProfessorRolesTable courseId={course.courseId} isAdminView={true}/>}
-        </div>
-    );
-};
-
-const startDate = new Date(START_DATE);
-const endDate = new Date(END_DATE);
-const currentTerm = CURRENT_SEMESTER.substring(0, 2);
-const currentYear = CURRENT_SEMESTER.substring(2, 4);
-
-const AdminCourseCreator = ({ onSubmit }: { readonly onSubmit: () => void }) => {
-    const [courseId, setCourseId] = useState('');
-    const [name, setName] = useState('');
-    const [code, setCode] = useState('');
-    const [semester, setSemester] = useState(CURRENT_SEMESTER);
-    const [year, setYear] = useState(currentTerm);
-    const [term, setTerm] = useState(currentYear);
-
-    const disabled = courseId.trim().length === 0
-        || name.trim().length === 0
-        || code.trim().length === 0
-        || semester.trim().length === 0
-        || year.trim().length === 0
-        || term.trim().length === 0;
-
-    const onSave = () => {
-        const course: Omit<FireCourse, 'courseId'> = {
-            name,
-            code,
-            semester,
-            year,
-            term,
-            queueOpenInterval: 30,
-            charLimit: 140,
-            startDate: firebase.firestore.Timestamp.fromDate(startDate),
-            endDate: firebase.firestore.Timestamp.fromDate(endDate),
-            professors: [],
-            tas: []
-        };
-        firestore.collection('courses').doc(courseId).set(course).then(onSubmit);
-    };
-
-    return (
-        <div className="course">
-            <h2>Create New Course</h2>
-            <div className="course-section">
-                <h3>Course Id</h3>
-                <input type="text" value={courseId} onChange={e => setCourseId(e.currentTarget.value)} />
-            </div>
-            <div className="course-section">
-                <h3>Course Name</h3>
-                <input type="text" value={name} onChange={e => setName(e.currentTarget.value)} />
-            </div>
-            <div className="course-section">
-                <h3>Course Code</h3>
-                <input type="text" value={code} onChange={e => setCode(e.currentTarget.value)} />
-            </div>
-            <div className="course-section">
-                <h3>Semester</h3>
-                <input type="text" value={semester} onChange={e => setSemester(e.currentTarget.value)} />
-            </div>
-            <div className="course-section">
-                <h3>Year</h3>
-                <input type="text" value={year} onChange={e => setYear(e.currentTarget.value)} />
-            </div>
-            <div className="course-section">
-                <h3>Term</h3>
-                <input type="text" value={term} onChange={e => setTerm(e.currentTarget.value)} />
-            </div>
-            <div className="course-section">
-                <h3>Start Date</h3>
-                <div>{startDate.toLocaleDateString()}</div>
-            </div>
-            <div className="course-section">
-                <h3>End Date</h3>
-                <div>{endDate.toLocaleDateString()}</div>
-            </div>
-            <button type="button" disabled={disabled} onClick={onSave}>Save</button>
-        </div>
-    );
-};
 
 const AdminView = () => {
     const courses = useAllCourses();
@@ -207,25 +14,42 @@ const AdminView = () => {
 
     return (
         <div className="AdminView">
+            <TopBar
+                    user={useMyUser()}
+                    // In admin view, it is never the case that the Dashboard section should be shown.
+                    role="student"
+                    context="professor"
+                    // This field is only necessary for professors, but we are always student/TA here.
+                    courseId="DUMMY_COURSE_ID"
+                />
             <h2>Courses</h2>
-            <div className="course-container">
-                {courses.filter(course => course.semester === CURRENT_SEMESTER).map(course => (
-                    <AdminCourseCard key={course.courseId} course={course} />
-                ))}
-                {inCreationMode && <AdminCourseCreator onSubmit={() => setInCreationMode(false)} />}
+            <div className="course-container" >
+                <Grid container direction="row" alignItems={'stretch'} spacing={3}>
+                    {courses.filter(course => course.semester === CURRENT_SEMESTER).map(course => (
+                        <Grid item xl = {3} lg={4} md={6} xs={12}>
+                            <AdminCourseCard key={course.courseId} course={course} />
+                        </Grid>
+                    ))}
+                </Grid>
             </div>
 
+            {inCreationMode && <AdminCourseCreator onSubmit={() => setInCreationMode(false)} />}
+
             {!inCreationMode &&
-                <button type="button" onClick={() => setInCreationMode(true)}>Create New Course</button>}
+                <button type="button" className="create-course" onClick={() => setInCreationMode(true)}>Create New Course</button>}
 
             <h2>Archived Courses</h2>
             <div className="course-container">
-                {courses.filter(course => course.semester !== CURRENT_SEMESTER).map(course => (
-                    <AdminCourseCard key={course.courseId} course={course} />
-                ))}
+                <Grid container direction="row" alignItems={'stretch'} spacing={3}>
+                    {courses.filter(course => course.semester !== CURRENT_SEMESTER).map(course => (
+                        <Grid item xl = {3} lg={4} md={6} xs={12}>
+                            <AdminCourseCard key={course.courseId} course={course} />
+                        </Grid>
+                    ))}
+                </Grid>
             </div>
             {!inCreationMode &&
-                <button type="button" onClick={() => setInCreationMode(true)}>Create New Course</button>}
+                <button type="button" className="create-course" onClick={() => setInCreationMode(true)}>Create New Course</button>}
         </div>
     );
 };

--- a/src/components/pages/AdminView.tsx
+++ b/src/components/pages/AdminView.tsx
@@ -15,18 +15,18 @@ const AdminView = () => {
     return (
         <div className="AdminView">
             <TopBar
-                    user={useMyUser()}
-                    // In admin view, it is never the case that the Dashboard section should be shown.
-                    role="student"
-                    context="professor"
-                    // This field is only necessary for professors, but we are always student/TA here.
-                    courseId="DUMMY_COURSE_ID"
-                />
+                user={useMyUser()}
+                // In admin view, it is never the case that the Dashboard section should be shown.
+                role="student"
+                context="professor"
+                // This field is only necessary for professors, but we are always student/TA here.
+                courseId="DUMMY_COURSE_ID"
+            />
             <h2>Courses</h2>
             <div className="course-container" >
                 <Grid container direction="row" alignItems={'stretch'} spacing={3}>
                     {courses.filter(course => course.semester === CURRENT_SEMESTER).map(course => (
-                        <Grid item xl = {3} lg={4} md={6} xs={12}>
+                        <Grid item xl={3} lg={4} md={6} xs={12}>
                             <AdminCourseCard key={course.courseId} course={course} />
                         </Grid>
                     ))}
@@ -49,7 +49,11 @@ const AdminView = () => {
                 </Grid>
             </div>
             {!inCreationMode &&
-                <button type="button" className="create-course" onClick={() => setInCreationMode(true)}>Create New Course</button>}
+                <button 
+                    type="button" 
+                    className="create-course" 
+                    onClick={() => setInCreationMode(true)}
+                >Create New Course</button>}
         </div>
     );
 };

--- a/src/components/pages/AdminView.tsx
+++ b/src/components/pages/AdminView.tsx
@@ -38,7 +38,7 @@ const AdminView = () => {
             {!inCreationMode &&
                 <button 
                     type="button" 
-                    className="create-course" 
+                    className="create-course-btn" 
                     onClick={() => setInCreationMode(true)}
                 >Create New Course</button>}
 

--- a/src/styles/AdminView.scss
+++ b/src/styles/AdminView.scss
@@ -8,7 +8,7 @@
         padding: 2em;
     }
 
-    .create-course {
+    .create-course-btn {
         display: inline-block;
         background-color: white;
         border: solid 1px #484848;

--- a/src/styles/AdminView.scss
+++ b/src/styles/AdminView.scss
@@ -1,21 +1,61 @@
 .AdminView {
+    position: relative;
     .course-container {
-        display: grid;
-        grid-template-columns: auto auto auto auto;
-        grid-gap: 5%;
+        width: 100%;
+        display: flex;
         flex-direction: row;
-        justify-content: center;
-        align-content: center;
+        align-items: stretch;
+        padding: 2em;
+    }
+
+    .create-course {
+        display: inline-block;
+        background-color: white;
+        border: solid 1px #484848;
+        margin: 5px;
+        width: 150px;
+        height: 40px;
+        border-radius: 4px;
+        text-decoration: none;
+        cursor: pointer;
     }
 
     .course {
         width: 100%;
         margin: 1em auto;
         padding: 1em;
-        border: 1px solid #ccc;
+        min-height: 100%;
 
         .course-section {
             margin: 1em;
         }
+
+        .editing-button {
+            display: inline-block;
+            background-color: white;
+            border: solid 1px #484848;
+            border-radius: 4px;
+            text-decoration: none;
+            padding: .5em;
+            margin: .25em;
+            cursor: pointer;
+        }
+    
+        .roles-button {
+            display: inline-block;
+            background-color: white;
+            border: solid 1px #484848;
+            border-radius: 4px;
+            text-decoration: none;
+            padding: .5em;
+            margin: .25em;
+            cursor: pointer;
+        }
+    }
+}
+
+@media(max-width: $mobile-breakpoint) {
+    .AdminView {
+        background-color: #f5f5f5;
     }
 }

--- a/src/styles/professor/ProfessorRoles.scss
+++ b/src/styles/professor/ProfessorRoles.scss
@@ -5,9 +5,20 @@
 
 .rolesTable {
     max-width: 800px;
-    margin: 40px auto !important;
+    margin-top: 40px !important;
 
     th {
         font-weight: 500;
+    }
+
+    .import-buttons {
+        display: flex;
+        width: 100%;
+        align-items: center;
+        justify-content: center;
+
+        button {
+            margin: .25em;
+        }
     }
 }


### PR DESCRIPTION
### Summary <!-- Required -->

I utilized the Material UI package to refactor the grid system for the courses and make it more responsive, styled some of the buttons, made the courses into Material UI Cards, refactored out the multiple components in the AdminView file, and added the TopBar to the admin page.

- Replaced the current grid style system with Grid components from @material-ui, which also makes the grid responsive--four courses per row on a very large screen, three per large, two per small, one per extra small. This fixes #497.
- Refactored the code within AdminView, which contained four functional components internally. These have been separated into /includes/[AdminCourseCard, AdminCourseCreator, AdminEditableCourseCard, AdminReadOnlyCourseCard].
- Updates some styles for the AdminView page, such as turning the course cards into <Card> components from @material-ui, making the button styles more consistent with the rest of the site, and shifting the import buttons outside of the table of ProfessorRolesTable
- Added the TopBar to the admin page utilizing a new optional boolean prop, admin. If admin is true, it mimics the behavior of a student TopBar with the [edit] still visible in the dropdown, so all of the site can be navigated to from the admin page.


### Test Plan <!-- Required -->
These are the steps I followed to test the changes:
- Test that the AdminView Grid displays all information without overlapping on a variety of screen sizes/numbers of classes
- Test that the TopBar correctly displays the right information and navigates to the right pages
- Test that the admin page functionality still works with the refactoring (None of the functionality code has changed)
- Test that the new styles do not interfere with functionality and are responsive along with the Grid

### Notes <!-- Optional -->

There are a couple of other small style tweaks possibly worth implementing, such as the multiline dropdown at certain screen sizes in the roles table, or the structure of data in the cards. Also, functionality in editing for the "Save" and "To Read Only" should likely be combined, but because the admin page is internal perhaps it is unnecessary.

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
