### PR TITLE
Refactor backend logic from SplitView and SessionView

### DIFF
--- a/src/components/pages/SplitView.tsx
+++ b/src/components/pages/SplitView.tsx
@@ -9,7 +9,7 @@ import LeaveQueue from '../includes/LeaveQueue';
 
 import { useCourse, useSession, useMyUser } from '../../firehooks';
 import { firestore } from '../../firebase';
-
+import { removeStudentQuestion } from '../../firebasefunctions/sessionQuestion'
 import TopBar from '../includes/TopBar';
 
 // Also update in the main LESS file
@@ -91,18 +91,9 @@ const SplitView = (props: {
     };
 
     const removeQuestion = () => {
-        if (removeQuestionId !== undefined) {
-            const batch = firestore.batch();
-            const slotUpdate: Partial<FireQuestionSlot> = { status: 'retracted' };
-            const questionUpdate: Partial<FireQuestion> = slotUpdate;
-            batch.update(firestore.doc(`questionSlots/${removeQuestionId}`), slotUpdate);
-            batch.update(firestore.doc(`questions/${removeQuestionId}`), questionUpdate);
-            batch.commit();
-        }    
+        removeStudentQuestion(firestore, removeQuestionId);  
     }
-    
 
-    // Toggle warning
 
     return (
         <>

--- a/src/components/pages/SplitView.tsx
+++ b/src/components/pages/SplitView.tsx
@@ -9,7 +9,7 @@ import LeaveQueue from '../includes/LeaveQueue';
 
 import { useCourse, useSession, useMyUser } from '../../firehooks';
 import { firestore } from '../../firebase';
-import { removeStudentQuestion } from '../../firebasefunctions/sessionQuestion'
+import { removeQuestionbyID } from '../../firebasefunctions/sessionQuestion'
 import TopBar from '../includes/TopBar';
 
 // Also update in the main LESS file
@@ -91,7 +91,7 @@ const SplitView = (props: {
     };
 
     const removeQuestion = () => {
-        removeStudentQuestion(firestore, removeQuestionId);  
+        removeQuestionbyID(firestore, removeQuestionId);  
     }
 
 

--- a/src/firebasefunctions/sessionQuestion.ts
+++ b/src/firebasefunctions/sessionQuestion.ts
@@ -157,3 +157,22 @@ export const removeStudentQuestion = (
         batch.commit();
     }    
 }
+
+export const updateQuestion = (
+    db: firebase.firestore.Firestore,
+    virtualLocation: string,
+    questions: readonly FireQuestion[],
+    user: FireUser
+
+) => {
+    const batch = db.batch();
+
+    const questionUpdate: Partial<FireOHQuestion> = { answererLocation: virtualLocation };
+    questions.forEach((q) => {
+        if (q.answererId === user.userId && q.status === 'assigned') {
+            batch.update(db.doc(`questions/${q.questionId}`), questionUpdate);
+        }
+    });
+
+    batch.commit();
+}

--- a/src/firebasefunctions/sessionQuestion.ts
+++ b/src/firebasefunctions/sessionQuestion.ts
@@ -144,7 +144,7 @@ export const assignQuestionToTA = (
     batch.commit();
 }
 
-export const removeStudentQuestion = (
+export const removeQuestionbyID = (
     db: firebase.firestore.Firestore,
     removeQuestionId: string | undefined
 ) => {

--- a/src/firebasefunctions/sessionQuestion.ts
+++ b/src/firebasefunctions/sessionQuestion.ts
@@ -143,3 +143,17 @@ export const assignQuestionToTA = (
     batch.update(db.doc(`questions/${question.questionId}`), questionUpdate);
     batch.commit();
 }
+
+export const removeStudentQuestion = (
+    db: firebase.firestore.Firestore,
+    removeQuestionId: string | undefined
+) => {
+    if (removeQuestionId !== undefined) {
+        const batch = db.batch();
+        const slotUpdate: Partial<FireQuestionSlot> = { status: 'retracted' };
+        const questionUpdate: Partial<FireQuestion> = slotUpdate;
+        batch.update(db.doc(`questionSlots/${removeQuestionId}`), slotUpdate);
+        batch.update(db.doc(`questions/${removeQuestionId}`), questionUpdate);
+        batch.commit();
+    }    
+}


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->

<!-- Add your summary here -->
Moved the logic in SessionView that is responsible for updating the virtual location of a question after a TA assigns themself to that question to the sessionQuestion file. 

Moved the logic in SplitView that is responsible for removing a student's question from the queue to the sessionQuestion file. 

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->

<!-- Briefly describe how you test you changes. -->
Ask a question then remove it, the question should be marked as retracted in the database (verify by looking at data in firestore) 

As a TA, assign a student's question to yourself. The student should be able to navigate to your virtual location when they click on join. 
### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
