### PR TITLE
Restricting front end access to /admin and /blog

### DIFF
--- a/src/components/pages/AdminView.tsx
+++ b/src/components/pages/AdminView.tsx
@@ -1,16 +1,24 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import {useHistory} from 'react-router'
 import {Grid} from '@material-ui/core'
 
 import TopBar from '../includes/TopBar';
 import AdminCourseCard from '../includes/AdminCourseCard';
 import AdminCourseCreator from '../includes/AdminCourseCreator';
-import { useAllCourses, useMyUser } from '../../firehooks';
+import { useAllCourses, useMyUser, useIsAdmin } from '../../firehooks';
 import { CURRENT_SEMESTER } from '../../constants';
 
 
 const AdminView = () => {
+    const history = useHistory();
     const courses = useAllCourses();
+    const isAdmin = useIsAdmin();
     const [inCreationMode, setInCreationMode] = useState(false);
+    useEffect(() => {
+        if(isAdmin === undefined) {
+            history.push('/')
+        }
+    }, [isAdmin])
 
     return (
         <div className="AdminView">

--- a/src/components/pages/AdminView.tsx
+++ b/src/components/pages/AdminView.tsx
@@ -18,7 +18,7 @@ const AdminView = () => {
         if(isAdmin === undefined) {
             history.push('/')
         }
-    }, [isAdmin])
+    }, [isAdmin, history])
 
     return (
         <div className="AdminView">

--- a/src/components/pages/BlogCMS.tsx
+++ b/src/components/pages/BlogCMS.tsx
@@ -11,10 +11,10 @@ const BlogCMS = () => {
     const history = useHistory();
     const isAdmin = useIsAdmin();
     useEffect(() => {
-      if(isAdmin === undefined) {
-          history.push('/')
-      }
-  }, [isAdmin])
+        if(isAdmin === undefined) {
+            history.push('/')
+        }
+    }, [isAdmin, history])
     return (
         <>
             <TopBar

--- a/src/components/pages/BlogCMS.tsx
+++ b/src/components/pages/BlogCMS.tsx
@@ -1,12 +1,20 @@
-import React from 'react'
+import React, {useEffect} from 'react'
+import {useHistory} from 'react-router'
 
 import AddBlogPost from '../includes/AddBlogPost';
 import BlogPostDisplay from '../includes/BlogPostDisplay';
 import TopBar from '../includes/TopBar';
 
-import { useMyUser } from '../../firehooks';
+import { useMyUser, useIsAdmin } from '../../firehooks';
 
 const BlogCMS = () => {
+    const history = useHistory();
+    const isAdmin = useIsAdmin();
+    useEffect(() => {
+      if(isAdmin === undefined) {
+          history.push('/')
+      }
+  }, [isAdmin])
     return (
         <>
             <TopBar

--- a/src/components/types/fireData.d.ts
+++ b/src/components/types/fireData.d.ts
@@ -187,3 +187,5 @@ interface BlogPost {
     timeEntered: FireTimestamp;
     edited? : FireTimestamp;
 }
+
+interface Admin {}

--- a/src/components/types/fireData.d.ts
+++ b/src/components/types/fireData.d.ts
@@ -187,5 +187,3 @@ interface BlogPost {
     timeEntered: FireTimestamp;
     edited? : FireTimestamp;
 }
-
-interface Admin {}

--- a/src/firebasefunctions/blogPost.ts
+++ b/src/firebasefunctions/blogPost.ts
@@ -22,7 +22,7 @@ export const addBlogPost = (
         batch.commit();
 
         return true;
-    } else return false;
+    } return false;
 }
 
 export const editBlogPost = (user: firebase.User | null, db: firebase.firestore.Firestore, blogPost: BlogPost) => {

--- a/src/firehooks.ts
+++ b/src/firehooks.ts
@@ -117,13 +117,13 @@ export const usePendingUser: () => FirePendingUser | undefined  =
 
 const isAdminObservable = loggedIn$.pipe(
     switchMap(u => 
-        docData(firestore.doc('admins/' + u.email)) as Observable<Admin>
+        docData(firestore.doc('admins/' + u.email)) as Observable<{}>
     )
 )
 
 export const isAdminSingletonObservable = new SingletonObservable(undefined, isAdminObservable);
 
-export const useIsAdmin : () => Admin | undefined = 
+export const useIsAdmin: () => {} | undefined = 
     createUseSingletonObservableHook(isAdminSingletonObservable);
 
 const allCoursesObservable: Observable<readonly FireCourse[]> = loggedIn$.pipe(

--- a/src/firehooks.ts
+++ b/src/firehooks.ts
@@ -115,6 +115,17 @@ export const needsPromotionSingletonObservable = new SingletonObservable(undefin
 export const usePendingUser: () => FirePendingUser | undefined  = 
     createUseSingletonObservableHook(needsPromotionSingletonObservable);
 
+const isAdminObservable = loggedIn$.pipe(
+    switchMap(u => 
+        docData(firestore.doc('admins/' + u.email)) as Observable<Admin>
+    )
+)
+
+export const isAdminSingletonObservable = new SingletonObservable(undefined, isAdminObservable);
+
+export const useIsAdmin : () => Admin | undefined = 
+    createUseSingletonObservableHook(isAdminSingletonObservable);
+
 const allCoursesObservable: Observable<readonly FireCourse[]> = loggedIn$.pipe(
     switchMap(() => collectionData<FireCourse>(firestore.collection('courses'), 'courseId'))
 );


### PR DESCRIPTION
### Summary <!-- Required -->

Adding admins collection to database, adapting security rules to use the admins collection, and blocking access to /admin and /blog in the front end.

### Test Plan <!-- Required -->

- Verify that with admin privileges (which consists of your email being in the admins collection) allow you to access secure resources and the /admin and /blog routes.
- Verify that removing yourself from the admins collection prevents access to secured resources and redirects you from the /admin and /blog routes when you attempt to access them.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
