### PR TITLE
Fix notification reference error for ios devices

### DIFF
--- a/src/components/pages/SplitView.tsx
+++ b/src/components/pages/SplitView.tsx
@@ -143,8 +143,9 @@ const SplitView = (props: {
                                 Please select an office hour from the calendar.
                                 <p> </p>
                                 <p> </p>
-
-                                {(Notification !== undefined) && Notification.permission === "granted" && (
+                                {("Notification" in window &&
+                                window?.Notification !== undefined) && 
+                                window?.Notification.permission === "granted" && (
                                     <div className="warningArea">
 
                                         <div>


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Add your summary here -->
Fixes issue #526. The notification reference error was caused because there is no variable named `Notification` (this variable is stored in window) so it must be referenced using `window?.Notification`
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->

<!-- Briefly describe how you test you changes. -->
Connect ios device to macbook with a cable. Run `ifconfig` in terminal to find the ip address that you need to run localhost on ios device. Open `http://<ip address>:3000 `. Sign in** and select an office hour session. The app should redirect you to that session (and should not crash). 

** You need to authorize the domain that you're using to sign into the app using firebase. To do this, go [here](https://console.firebase.google.com/u/1/project/qmi-test/authentication/providers) and add the ip address to authorized domains.
### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
