### PR TITLE
Change all professor/ta email inputs to lowercase

### DIFF
--- a/src/components/includes/CSVUploadView.tsx
+++ b/src/components/includes/CSVUploadView.tsx
@@ -75,7 +75,7 @@ const CSVUploadView = (
             if (TAEmailList && TAEmailList.length !== 0 && professorEmailList && professorEmailList.length !== 0) {
                 importProfessorsOrTAsFromCSV(course, 'ta', TAEmailList)?.then((users) => {
                     const taAddedEmails = users.updatedUsers.map(user => user.email);  
-                    const taMissingEmails = Array.from(users.missingSet);   
+                    const taMissingEmails = Array.from(users.missingSet);  
                     return {taAddedEmails, taMissingEmails}
                 }).then((taEmails)=> {
                     importProfessorsOrTAsFromCSV(course, 'professor', professorEmailList)?.then((users) => {
@@ -220,8 +220,8 @@ const CSVUploadView = (
                         setCSVErrorMessage('Please enter valid roles only (TA or Professor)');
                     }
 
-                    const TAEmailList = TAList.map(user => user.split(',')[0].trim());
-                    const professorEmailList = professorList.map(user => user.split(',')[0].trim());
+                    const TAEmailList = TAList.map(user => user.split(',')[0].trim().toLowerCase());
+                    const professorEmailList = professorList.map(user => user.split(',')[0].trim().toLowerCase());
 
                     setTAEmailList(TAEmailList);
                     setProfessorEmailList(professorEmailList);
@@ -250,8 +250,8 @@ const CSVUploadView = (
             const TAList = newUsers.filter(user => user.role === 'TA'); 
             const professorList = newUsers.filter(user => user.role === 'Professor')
 
-            const TAEmailList = TAList.map(user => user.email);
-            const professorEmailList = professorList.map(user => user.email);
+            const TAEmailList = TAList.map(user => user.email.toLowerCase());
+            const professorEmailList = professorList.map(user => user.email.toLowerCase());
 
             setTAEmailList(TAEmailList);
             setProfessorEmailList(professorEmailList);


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->

<!-- Add your summary here -->
Change email inputs to lowercase to avoid issues when adding new professors/tas. Previously, if the ta/professor email was all uppercase, a new pending user would be created  in firestore with an all uppercase email. 

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->

<!-- Briefly describe how you test you changes. -->
Add a new professor/ta with an uppercase email. A new pending user should not be created with an all uppercase email in firestore.
### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
