### PR TITLE
Fixing issue with retaining session while changing classes

### DIFF
--- a/src/components/includes/CalendarView.tsx
+++ b/src/components/includes/CalendarView.tsx
@@ -15,9 +15,10 @@ type Props = {
     sessionCallback: (sessionId: string) => void;
     course?: FireCourse;
     user?: FireUser;
+    isActiveSession: boolean;
 };
 
-const CalenderView = ({ session, sessionCallback, course, user }: Props) => {
+const CalenderView = ({ session, sessionCallback, course, user, isActiveSession }: Props) => {
     const [selectedDateEpoch, setSelectedDate] = React.useState(new Date().setHours(0, 0, 0, 0));
     const selectedDate = new Date(selectedDateEpoch);
     selectedDate.setHours(0, 0, 0, 0);
@@ -43,7 +44,7 @@ const CalenderView = ({ session, sessionCallback, course, user }: Props) => {
             <CalendarDaySelect callback={setSelectedDate} />
             {course && user && sessions ? (
                 <CalendarSessions
-                    activeSession={session}
+                    activeSession={isActiveSession? session : undefined}
                     callback={sessionCallback}
                     course={course}
                     sessions={filteredSessions || []}

--- a/src/components/includes/SessionQuestion.tsx
+++ b/src/components/includes/SessionQuestion.tsx
@@ -130,8 +130,9 @@ class SessionQuestion extends React.Component<Props, State> {
     }
 
     componentWillUnmount() {
+
         if(this.props.myUserId === this.props.question.askerId) {
-            if(this.props.question.status !== 'unresolved') {
+            if(this.props.question.status !== 'unresolved' && this.props.index === -1) {
                 addNotificationWrapper(
                     this.props.user, 
                     'Question Marked as Complete', 

--- a/src/components/includes/SessionQuestion.tsx
+++ b/src/components/includes/SessionQuestion.tsx
@@ -131,12 +131,21 @@ class SessionQuestion extends React.Component<Props, State> {
 
     componentWillUnmount() {
         if(this.props.myUserId === this.props.question.askerId) {
-            addNotificationWrapper(
-                this.props.user, 
-                'Question Marked as Complete', 
-                'Question marked as complete', 
-                'Your question has been marked as complete/no-show.');
-            window.localStorage.setItem('questionUpNotif', '');
+            if(this.props.question.status !== 'unresolved') {
+                addNotificationWrapper(
+                    this.props.user, 
+                    'Question Marked as Complete', 
+                    'Question marked as complete', 
+                    'Your question has been marked as complete/no-show.');
+                window.localStorage.setItem('questionUpNotif', '');
+            } else if (this.props.index === -1){
+                addNotificationWrapper(
+                    this.props.user, 
+                    'Question Removed', 
+                    'Question removed', 
+                    'Your question has been removed from the queue.');
+                window.localStorage.setItem('questionUpNotif', '');
+            }
         } 
     }
 

--- a/src/components/pages/SplitView.tsx
+++ b/src/components/pages/SplitView.tsx
@@ -64,7 +64,7 @@ const SplitView = (props: {
     const course = useCourse(props.match.params.courseId);
     const session = useSession(props.match.params.sessionId);
     const width = useWindowWidth();
-
+    
     // Handle browser back button
     props.history.listen((location) => {
         setActiveView(
@@ -113,6 +113,7 @@ const SplitView = (props: {
                     course={course}
                     session={session}
                     sessionCallback={handleSessionClick}
+                    isActiveSession={props.match.params.sessionId === session?.sessionId}
                 />}
                 
             {"Notification" in window &&
@@ -122,7 +123,7 @@ const SplitView = (props: {
                 
             {(width > MOBILE_BREAKPOINT || activeView !== 'calendar') &&
                 ((course && user) ? (
-                    session ? (
+                    (session && props.match.params.sessionId === session.sessionId) ? (
                         <SessionView
                             course={course}
                             session={session}


### PR DESCRIPTION
### Summary <!-- Required -->

I discovered a bug with changing classes while having an office hour highlighted--the session hook does not change even though the props to SessionQuestionsContainer does. This essentially means that a user who switches from a class they are a student in to a class they are a TA in will still be viewing the session for the class they are a student in, but will now have the TA role because the course displayed has changed. This secondarily caused a significant number of erroneous and odd notifications to be outputted. 

I also discovered a secondary bug where asking a question and then switching courses sends the "question marked as complete" notification because the component unmounts. There are now three cases when the question component unmounts:
1. The user removed the question themselves. This sets the index to -1 (even though the status is not yet updated) and thus the "question removed" notification is now sent
2. A TA marks the question as done/no-show. This only occurs when the status is 'assigned', and the index is also set to -1.
3. The component is unmounted because the user navigated away--this can occur at any status, but the question index will never be -1 for a question still on the queue.

I fixed the first bug by adding a check to session rendering (and active session rendering on the calendar view) that ensures that the url session id (which changes when the user navigates to another course, but the session hook does not necessarily do so) is equal to the session hook session id.

The second bug is fixed by checking that the question index is -1 when the component unmounts before sending any notifications.

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->
Here is what I did to test both bugs were gone:

Bug 1
- Add a question
- Navigate to another course (any course, but testing with one where you have a role is ideal because that is where the bug originated)
- Ensure that no session is selected/visible when this occurs

Bug 2
- Add a question
- Remove it (Testing the "remove" notification sends correctly)
- Add a question
- Mark as done, and separately make another question and mark as no show, and ensure the correct notifications are sent
- Add a question, but don't assign it
- Navigate to another course, and navigate back, ensuring no notifications are sent.
- Assign that question as a TA
- Navigate again and back, ensuring no notifications are sent.
- mark the question as done or no show or remove it, and navigate away and back again and ensure no additional notifications are sent.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
