### PR TITLE
Adding collapsing past office hours, fixing 24 hour time on notifications

### DIFF
--- a/src/components/includes/CalendarSessions.tsx
+++ b/src/components/includes/CalendarSessions.tsx
@@ -1,5 +1,6 @@
-import React, { Dispatch, SetStateAction, ReactElement } from 'react';
+import React, { Dispatch, SetStateAction, ReactElement, useState } from 'react';
 import { groupBy } from 'lodash';
+import {Icon} from 'semantic-ui-react'
 
 import CalendarSessionCard from './CalendarSessionCard';
 import CalendarExport from '../../media/calendar_export.svg';
@@ -61,6 +62,13 @@ const CalendarSessions = ({
         sessionCards &&
         groupBy(sessionCards, (card: ReactElement) => card.props.status);
 
+    const [num, inc] = useState(0);
+    const [collapsed, setCollapsed] = useState('Open' in groupedCards || 'Ongoing' in groupedCards || 'Upcoming' in groupedCards);
+
+    React.useEffect(() => {
+        inc(num + 1);
+    }, [collapsed])
+
     const showCalendarExportModal = () => {
         setShowCalendarModal(true);
         setIsDayExport(true);
@@ -113,12 +121,22 @@ const CalendarSessions = ({
             }
             {groupedCards && (
                 <>
-                    {'Past' in groupedCards && (
+                    {'Past' in groupedCards && (collapsed ? (
                         <>
-                            <h6>Past</h6>
-                            {groupedCards.Past}
+                            <div className="pastHeader">
+                                <h6>Past</h6>
+                                <Icon name='chevron down' onClick={() => {console.log("setting collapsed to false"); setCollapsed(false)}}/>
+                            </div>
                         </>
-                    )}
+                    ) : 
+                    (<>
+                        <div className="pastHeader">
+                            <h6>Past</h6>
+                            <Icon name='chevron up' onClick={() => setCollapsed(true)}/>
+                        </div>
+                        {groupedCards.Past}
+                    </>
+                    ))}
                     {'Open' in groupedCards && (
                         <>
                             <h6>Open</h6>

--- a/src/components/includes/CalendarSessions.tsx
+++ b/src/components/includes/CalendarSessions.tsx
@@ -62,13 +62,12 @@ const CalendarSessions = ({
         sessionCards &&
         groupBy(sessionCards, (card: ReactElement) => card.props.status);
 
-    const [collapsed, setCollapsed] = useState('Open' in groupedCards || 'Ongoing' in groupedCards || 'Upcoming' in groupedCards);
+    const [collapsed, setCollapsed] = useState(
+        'Open' in groupedCards || 
+      'Ongoing' in groupedCards || 
+      'Upcoming' in groupedCards
+    );
 
-    React.useEffect(() => {
-        if(collapsed) {
-            setCollapsed('Open' in groupedCards || 'Ongoing' in groupedCards || 'Upcoming' in groupedCards);
-        }
-    }, [groupedCards])
 
     const showCalendarExportModal = () => {
         setShowCalendarModal(true);
@@ -126,18 +125,18 @@ const CalendarSessions = ({
                         <>
                             <div className="pastHeader">
                                 <h6>Past</h6>
-                                <Icon name='chevron down' onClick={() => {console.log("setting collapsed to false"); setCollapsed(false)}}/>
+                                <Icon name='chevron down' onClick={() => {setCollapsed(false)}}/>
                             </div>
                         </>
                     ) : 
-                    (<>
-                        <div className="pastHeader">
-                            <h6>Past</h6>
-                            <Icon name='chevron up' onClick={() => setCollapsed(true)}/>
-                        </div>
-                        {groupedCards.Past}
-                    </>
-                    ))}
+                        (<>
+                            <div className="pastHeader">
+                                <h6>Past</h6>
+                                <Icon name='chevron up' onClick={() => setCollapsed(true)}/>
+                            </div>
+                            {groupedCards.Past}
+                        </>
+                        ))}
                     {'Open' in groupedCards && (
                         <>
                             <h6>Open</h6>

--- a/src/components/includes/CalendarSessions.tsx
+++ b/src/components/includes/CalendarSessions.tsx
@@ -62,12 +62,13 @@ const CalendarSessions = ({
         sessionCards &&
         groupBy(sessionCards, (card: ReactElement) => card.props.status);
 
-    const [num, inc] = useState(0);
     const [collapsed, setCollapsed] = useState('Open' in groupedCards || 'Ongoing' in groupedCards || 'Upcoming' in groupedCards);
 
     React.useEffect(() => {
-        inc(num + 1);
-    }, [collapsed])
+        if(collapsed) {
+            setCollapsed('Open' in groupedCards || 'Ongoing' in groupedCards || 'Upcoming' in groupedCards);
+        }
+    }, [groupedCards])
 
     const showCalendarExportModal = () => {
         setShowCalendarModal(true);

--- a/src/components/includes/TopBarNotifications.tsx
+++ b/src/components/includes/TopBarNotifications.tsx
@@ -94,7 +94,7 @@ const TopBarNotifications = ({notificationTracker, user}: Props) => {
                                 className="notification__date" 
                                 date={notific.createdAt.toDate()} 
                                 interval={0} 
-                                format={'HH:mm a'} 
+                                format={'hh:mm a'} 
                             />
                         </div>
                         <div className="notification__content">

--- a/src/styles/calendar/CalendarSessions.scss
+++ b/src/styles/calendar/CalendarSessions.scss
@@ -35,6 +35,20 @@ $open: #ffdba6;
     }
 }
 
+.CalendarSessions {
+    .pastHeader {
+        display: flex;
+        flex-direction: row;
+        width: 100%;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 10px;
+        .icon {
+            cursor: pointer;
+        }
+    }
+}
+
 .CalendarSessions h6 {
     font-size: 14px;
     font-weight: normal;


### PR DESCRIPTION
### Summary <!-- Required -->

Makes past office hours automatically collapsed (unless there are no current office hours) and allows expanding as well. Also makes the time for notifications in 12 hour, not 24 hour. 

<!-- Add your summary here -->

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->

- Have a course with at least one past office hour and at least one current office hour. On clicking the course (or refresh), the past office hours should be automatically collapsed but able to be expanded.
- Have a course with only past office hours. They should be automatically expanded on clicking on the course (or refreshing), but still able to be collapsed
- check that a notif past noon has 12 hour time, with am/pm correct.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
