### PR TITLE
fixed alignment for dashboard warning

### DIFF
--- a/src/styles/SplitView.scss
+++ b/src/styles/SplitView.scss
@@ -1,6 +1,6 @@
 div.warningArea {
     padding: 0.3in;
-    display: inline-block;
+    text-align: center;
 }
 
 aside.CalendarView {


### PR DESCRIPTION
**Summary** 

The alignment for the dashboard was misaligned and was squished with the "Please select an office hour from the calendar."
So I made a css style change and changed the display from inline to center text alignment and was able to see a visible improvement after I ran this on my computer. 


**Test Plan**

I've tested that changing the size of the screen would keep the warning in the center.
<img width="1427" alt="image" src="https://user-images.githubusercontent.com/53349391/195886999-da400593-919d-4718-88b7-aecb35e329c9.png">

**Notes**

**Breaking Changes**

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
