### PR TITLE
Fix chat messages order

### DIFF
--- a/src/components/includes/CommentsContainer.tsx
+++ b/src/components/includes/CommentsContainer.tsx
@@ -18,7 +18,7 @@ const CommentsContainer = ({ users, currentUser, addCommentsHelper, questionId,
     switchCommentsVisible, deleteCommentsHelper, showNewComment, isPast }: Props) => {
 
     const comments = useParameterizedComments(questionId);
-    const sortedComments = [...comments].sort((c1, c2) => c2.timePosted.seconds - c1.timePosted.seconds);
+    const sortedComments = [...comments].sort((c1, c2) => c1.timePosted.seconds - c2.timePosted.seconds);
     return (
         <div className="commentsContainer">
             {(showNewComment || comments.length > 0) &&

--- a/src/components/includes/CommentsContainer.tsx
+++ b/src/components/includes/CommentsContainer.tsx
@@ -25,10 +25,6 @@ const CommentsContainer = ({ users, currentUser, addCommentsHelper, questionId,
                 <div className="commentsLine" onClick={switchCommentsVisible} />
             }
             <div className="allCommentsWrapper">
-                {showNewComment && !isPast && <NewComment
-                    currentUser={currentUser}
-                    addCommentsHelper={addCommentsHelper}
-                />}
                 {sortedComments.map((comment) => {
                     const poster = users[comment.commenterId];
                     return <UserComment
@@ -41,6 +37,10 @@ const CommentsContainer = ({ users, currentUser, addCommentsHelper, questionId,
                         isPast={isPast}
                     />
                 })}
+                {showNewComment && !isPast && <NewComment
+                    currentUser={currentUser}
+                    addCommentsHelper={addCommentsHelper}
+                />}
             </div>
         </div>
 


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->

1. Updates order of chat messages to be by ascending time rather than descending time
2. Moves reply/new comment to bottom of list of comments/chat messages

Before:
<img width="960" alt="Screen Shot 2023-03-01 at 10 48 13 AM" src="https://user-images.githubusercontent.com/45403687/222193727-47539bb2-64d0-412d-a5e1-0f4174b8cef6.png">

After:
<img width="961" alt="Screen Shot 2023-03-01 at 10 47 28 AM" src="https://user-images.githubusercontent.com/45403687/222193758-358cb6cc-ad06-452e-bf7c-4ef5d676cab3.png">

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->

Tested by adding, viewing, and deleting chat messages during office hours in both Student and Professor/TA view. 

<!-- Briefly describe how you test you changes. -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
