### PR TITLE
Per TA Analytics

### DIFF
--- a/src/components/pages/ProfessorPeopleView.tsx
+++ b/src/components/pages/ProfessorPeopleView.tsx
@@ -46,11 +46,9 @@ const ProfessorPeopleView = (props: RouteComponentProps<{ courseId: string }>) =
     const [selectedTA, setSelectedTA] = useState<FireUser>()
 
     useEffect(() => {
-        const input = TAName.split(" ")
-        if (input.length !== 0) {
+        if (TAName.length !== 0) {
             const filtered = allTAs.filter((ta) =>
-                ta && ta.firstName.toLowerCase().startsWith(input[0]) &&
-                (input.length === 1 || ta.lastName.toLowerCase().startsWith(input[1])))
+                ta && ta.email.toLowerCase().startsWith(TAName))
             setFilteredTAs(filtered)
         } else {
             setFilteredTAs(allTAs)
@@ -261,34 +259,21 @@ const ProfessorPeopleView = (props: RouteComponentProps<{ courseId: string }>) =
                                 </div>
                                 <div className="Most-Crowded-Box">
                                     <div className="most-crowded-text">
-                                        <p className="crown-title">TA Performance</p>
-                                        <div className="ta-info">
-                                            {selectedTA ?
-                                                (<div>
-                                                    <p className="maroon-date">{selectedTA.firstName} {selectedTA.lastName}</p>
-                                                    <p className="maroon-descript">{selectedTA.email}</p>
-                                                </div>) :
-                                                (<p className="maroon-date">Select a TA</p>)
-                                            }
-                                        </div>
-                                        <input
-                                            placeholder={"Enter TA Name"}
-                                            onChange={(e) => setTAName(e.target.value.toLowerCase())}
-                                        />
-                                        <div className="ta-results">
-                                            {filteredTAs.map((ta) => (
-                                                <button type="button" className="ta-result" onClick={e => setSelectedTA(ta)}>{ta.firstName} {ta.lastName}</button>
-                                            ))}
+                                        <div>
+                                            <p className="crowd-title">Average Wait Time</p>
+                                            <p className="maroon-date">
+                                                {totalAssignedQuestions ?
+                                                    `${(totalWaitTime / totalAssignedQuestions / 60).toFixed(2)} minutes`
+                                                    : "Not applicable"}
+                                            </p>
                                         </div>
                                     </div>
                                     <div className="questions-line-container">
-                                        <QuestionsBarGraph
-                                            barData={taGraphData}
-                                            yMax={taChartYMax}
-                                            sessionKeys={sessions.map((s) => s.sessionId)}
+                                        <QuestionsLineChart
+                                            lineData={averageWaitTimeLineChartQuestionsTest}
+                                            yMax={averageWaitTimeMax}
                                             calcTickVals={calcTickVals}
-                                            legend="questions"
-                                            sessionDict={sessionQuestionDict}
+                                            legend="minutes"
                                         />
                                     </div>
                                 </div>
@@ -333,21 +318,37 @@ const ProfessorPeopleView = (props: RouteComponentProps<{ courseId: string }>) =
                             </div>
                             <div className="Most-Crowded-Box">
                                 <div className="most-crowded-text">
-                                    <div>
-                                        <p className="crowd-title">Average Wait Time</p>
-                                        <p className="maroon-date">
-                                            {totalAssignedQuestions ?
-                                                `${(totalWaitTime / totalAssignedQuestions / 60).toFixed(2)} minutes`
-                                                : "Not applicable"}
-                                        </p>
+                                    <p className="crown-title">TA Performance</p>
+                                    <div className="ta-info">
+                                        {selectedTA ?
+                                            (<div>
+                                                <p className="maroon-date">{selectedTA.firstName} {selectedTA.lastName}</p>
+                                                <p className="maroon-descript">{selectedTA.email}</p>
+                                            </div>) :
+                                            (<div>
+                                                <p className="maroon-date">No TA Selected </p>
+                                                <p className="maroon-descript">Search for a TA using NetID</p>
+                                            </div>)
+                                        }
+                                    </div>
+                                    <input
+                                        placeholder={"Enter TA NetID"}
+                                        onChange={(e) => setTAName(e.target.value.toLowerCase())}
+                                    />
+                                    <div className="ta-results">
+                                        {filteredTAs.map((ta) => (
+                                            <button type="button" className="ta-result" onClick={e => setSelectedTA(ta)}>{ta.firstName} {ta.lastName} ({ta.email.split("@")[0]})</button>
+                                        ))}
                                     </div>
                                 </div>
                                 <div className="questions-line-container">
-                                    <QuestionsLineChart
-                                        lineData={averageWaitTimeLineChartQuestionsTest}
-                                        yMax={averageWaitTimeMax}
+                                    <QuestionsBarGraph
+                                        barData={taGraphData}
+                                        yMax={taChartYMax}
+                                        sessionKeys={sessions.map((s) => s.sessionId)}
                                         calcTickVals={calcTickVals}
-                                        legend="minutes"
+                                        legend="questions"
+                                        sessionDict={sessionQuestionDict}
                                     />
                                 </div>
                             </div>

--- a/src/components/pages/ProfessorPeopleView.tsx
+++ b/src/components/pages/ProfessorPeopleView.tsx
@@ -43,13 +43,14 @@ const ProfessorPeopleView = (props: RouteComponentProps<{ courseId: string }>) =
         ind === questionTAs.findIndex(elem => elem && elem.userId === ta.userId))
     const [filteredTAs, setFilteredTAs] = useState<FireUser[]>([])
     const [TAName, setTAName] = useState("")
+    const [selectedTA, setSelectedTA] = useState<FireUser>()
 
     useEffect(() => {
         const input = TAName.split(" ")
         if (input.length !== 0) {
             const filtered = allTAs.filter((ta) =>
-                ta && ta.firstName.toLowerCase().includes(input[0]) &&
-                (input.length === 1 || ta.lastName.toLowerCase().includes(input[1])))
+                ta && ta.firstName.toLowerCase().startsWith(input[0]) &&
+                (input.length === 1 || ta.lastName.toLowerCase().startsWith(input[1])))
             setFilteredTAs(filtered)
         } else {
             setFilteredTAs(allTAs)
@@ -184,22 +185,6 @@ const ProfessorPeopleView = (props: RouteComponentProps<{ courseId: string }>) =
         );
     }
 
-
-    const idOfTA = (taName: string) => {
-        const taUser = allTAs.find(ta => ta && ta.firstName === taName);
-        // const taUser = null;
-        // users.forEach((u) => console.log(u.firstName))
-        // sessions.forEach((s) => console.log(getUsersFromSessions(sessions)))
-        // const u = getUsersFromSessions(sessions)
-        // console.log(users)
-        // console.log(taUser ? taUser.userId : "None");
-        console.log(filteredTAs)
-        return taUser
-            ? taUser.userId
-            : 'No TA Assigned';
-        // return " "
-    };
-
     const taGraphData: BarDatum[] = [];
     const taQuestionsByDay: number[] = [];
     for (let i = 0; i < sessions.length; i++) {
@@ -211,7 +196,9 @@ const ProfessorPeopleView = (props: RouteComponentProps<{ courseId: string }>) =
             location: (session.modality === "virtual" || session.modality === "review") ? "Online" : session.building,
         };
         const x = moment(session.startTime.seconds * 1000).format("MMM D");
-        const taQuestions = questions[i] ? questions[i].filter((q) => q.answererId === idOfTA("Erin")) : []
+        const taQuestions = questions[i] ?
+            questions[i].filter((q) => selectedTA && q.answererId === selectedTA.userId)
+            : []
         const y = taQuestions.length
         const lastIndex = taGraphData.length - 1;
         if (taGraphData[lastIndex]?.x === x) {
@@ -272,45 +259,37 @@ const ProfessorPeopleView = (props: RouteComponentProps<{ courseId: string }>) =
                                         </p>
                                     </div>
                                 </div>
-                                {/* <div className="questions-bar-container">
-                                    <div className="bar-graph">
-                                        <QuestionsBarChart
-                                            barData={barGraphData}
+                                <div className="Most-Crowded-Box">
+                                    <div className="most-crowded-text">
+                                        <p className="crown-title">TA Performance</p>
+                                        {selectedTA ?
+                                            (<div>
+                                                <p className="maroon-date">{selectedTA.firstName} {selectedTA.lastName}</p>
+                                                <p className="maroon-descript">{selectedTA.email}</p>
+                                            </div>) :
+                                            (<p className="maroon-date">Select a TA</p>)
+                                        }
+                                        <input
+                                            placeholder={"Enter TA Name"}
+                                            onChange={(e) => setTAName(e.target.value.toLowerCase())}
+                                        />
+                                        <div className="ta-results">
+                                            {filteredTAs.map((ta) => (
+                                                <button type="button" className="ta-result" onClick={e => setSelectedTA(ta)}>{ta.firstName} {ta.lastName}</button>
+                                            ))}
+                                        </div>
+                                    </div>
+                                    <div className="questions-line-container">
+                                        <QuestionsBarGraph
+                                            barData={taGraphData}
+                                            yMax={taChartYMax}
                                             sessionKeys={sessions.map((s) => s.sessionId)}
-                                            sessionDict={sessionDict}
-                                            yMax={chartYMax}
                                             calcTickVals={calcTickVals}
+                                            legend="questions"
+                                            sessionDict={sessionQuestionDict}
                                         />
                                     </div>
-                                </div> */}
-                            </div>
-                            <div className="Most-Crowded-Box">
-                                <div className="most-crowded-text">
-                                    <p className="maroon-date">
-                                        Select a TA
-                                    </p>
-                                    <input
-                                        placeholder={"Enter TA Name"}
-                                        onChange={(e) => setTAName(e.target.value.toLowerCase())}
-                                    />
-                                    {filteredTAs.map((ta) => (
-                                        <p>{ta.firstName} {ta.lastName}</p>
-                                    ))}
                                 </div>
-                                <div className="questions-line-container">
-                                    <QuestionsBarGraph
-                                        barData={taGraphData}
-                                        yMax={taChartYMax}
-                                        sessionKeys={sessions.map((s) => s.sessionId)}
-                                        calcTickVals={calcTickVals}
-                                        legend="questions"
-                                        sessionDict={sessionQuestionDict}
-                                    />
-                                </div>
-
-                            </div>
-                            <div>
-                                {filteredTAs.length}
                             </div>
                             <div className="Most-Crowded-Box">
                                 {busiestSessionInfo && (

--- a/src/components/pages/ProfessorPeopleView.tsx
+++ b/src/components/pages/ProfessorPeopleView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { RouteComponentProps } from "react-router";
 import moment from "moment";
 import { DateRangePicker } from "react-dates";
@@ -35,6 +35,26 @@ const ProfessorPeopleView = (props: RouteComponentProps<{ courseId: string }>) =
     const unresolvedQuestions = allQuestions.filter((q) => q.status === "unresolved");
     const percentUnresolved = totalQuestions ? Math.round((100 * unresolvedQuestions.length) / totalQuestions) : 100;
     const percentResolved = 100 - percentUnresolved;
+
+    // TA data
+    // questionTAs includes undefined (for unanswered questions) and duplicates 
+    const questionTAs = allQuestions.map((q) => courseUsers[q.answererId])
+    const allTAs = questionTAs.filter((ta, ind) => ta &&
+        ind === questionTAs.findIndex(elem => elem && elem.userId === ta.userId))
+    const [filteredTAs, setFilteredTAs] = useState<FireUser[]>([])
+    const [TAName, setTAName] = useState("")
+
+    useEffect(() => {
+        const input = TAName.split(" ")
+        if (input.length !== 0) {
+            const filtered = allTAs.filter((ta) =>
+                ta && ta.firstName.toLowerCase().includes(input[0]) &&
+                (input.length === 1 || ta.lastName.toLowerCase().includes(input[1])))
+            setFilteredTAs(filtered)
+        } else {
+            setFilteredTAs(allTAs)
+        }
+    }, [TAName]);
 
     // Busiest Session Data
     const busiestSessionIndex = questions.reduce(
@@ -112,13 +132,14 @@ const ProfessorPeopleView = (props: RouteComponentProps<{ courseId: string }>) =
     }, 0);
 
     // Bar Chart
-    const sessionQuestionDict: { 
+    const sessionQuestionDict: {
         [id: string]: {
             ta: string;
             location: string;
             startHour: string;
             endHour: string;
-        };} = {}
+        };
+    } = {}
 
     let chartYMax = (questions[busiestSessionIndex] && questions[busiestSessionIndex].length) || 0;
 
@@ -140,10 +161,68 @@ const ProfessorPeopleView = (props: RouteComponentProps<{ courseId: string }>) =
             questionsByDay[questionsByDay.length - 1] += y;
             chartYMax = Math.max(chartYMax, questionsByDay[questionsByDay.length - 1]);
         } else {
-            barGraphData.push({x});
+            barGraphData.push({ x });
             barGraphData[lastIndex + 1][session.sessionId] = y;
             questionsByDay.push(y);
             chartYMax = Math.max(chartYMax, y);
+        }
+    }
+
+    // TA Chart
+    // const taQuestions = questions.flat().filter((q) => q.answererId === "jm0cHTzzw5Xejn2vLYmaoTY1Olq1")
+    let taChartYMax = (questions[busiestSessionIndex] && questions[busiestSessionIndex].length) || 0;
+
+    if (sessions.length === 0) {
+        return (
+            <tbody>
+                <tr>
+                    <td colSpan={5} className="NoOH">
+                        <i>No office hours scheduled</i>
+                    </td>
+                </tr>
+            </tbody>
+        );
+    }
+
+
+    const idOfTA = (taName: string) => {
+        const taUser = allTAs.find(ta => ta && ta.firstName === taName);
+        // const taUser = null;
+        // users.forEach((u) => console.log(u.firstName))
+        // sessions.forEach((s) => console.log(getUsersFromSessions(sessions)))
+        // const u = getUsersFromSessions(sessions)
+        // console.log(users)
+        // console.log(taUser ? taUser.userId : "None");
+        console.log(filteredTAs)
+        return taUser
+            ? taUser.userId
+            : 'No TA Assigned';
+        // return " "
+    };
+
+    const taGraphData: BarDatum[] = [];
+    const taQuestionsByDay: number[] = [];
+    for (let i = 0; i < sessions.length; i++) {
+        const session = sessions[i];
+        sessionQuestionDict[session.sessionId] = {
+            ta: session.tas.join(", "),
+            startHour: moment(session.startTime.seconds * 1000).format("h:mm a"),
+            endHour: moment(session.endTime.seconds * 1000).format("h:mm a"),
+            location: (session.modality === "virtual" || session.modality === "review") ? "Online" : session.building,
+        };
+        const x = moment(session.startTime.seconds * 1000).format("MMM D");
+        const taQuestions = questions[i] ? questions[i].filter((q) => q.answererId === idOfTA("Erin")) : []
+        const y = taQuestions.length
+        const lastIndex = taGraphData.length - 1;
+        if (taGraphData[lastIndex]?.x === x) {
+            taGraphData[lastIndex][session.sessionId] = y;
+            taQuestionsByDay[taQuestionsByDay.length - 1] += y;
+            taChartYMax = Math.max(taChartYMax, taQuestionsByDay[taQuestionsByDay.length - 1]);
+        } else {
+            taGraphData.push({ x });
+            taGraphData[lastIndex + 1][session.sessionId] = y;
+            taQuestionsByDay.push(y);
+            taChartYMax = Math.max(taChartYMax, y);
         }
     }
 
@@ -204,6 +283,34 @@ const ProfessorPeopleView = (props: RouteComponentProps<{ courseId: string }>) =
                                         />
                                     </div>
                                 </div> */}
+                            </div>
+                            <div className="Most-Crowded-Box">
+                                <div className="most-crowded-text">
+                                    <p className="maroon-date">
+                                        Select a TA
+                                    </p>
+                                    <input
+                                        placeholder={"Enter TA Name"}
+                                        onChange={(e) => setTAName(e.target.value.toLowerCase())}
+                                    />
+                                    {filteredTAs.map((ta) => (
+                                        <p>{ta.firstName} {ta.lastName}</p>
+                                    ))}
+                                </div>
+                                <div className="questions-line-container">
+                                    <QuestionsBarGraph
+                                        barData={taGraphData}
+                                        yMax={taChartYMax}
+                                        sessionKeys={sessions.map((s) => s.sessionId)}
+                                        calcTickVals={calcTickVals}
+                                        legend="questions"
+                                        sessionDict={sessionQuestionDict}
+                                    />
+                                </div>
+
+                            </div>
+                            <div>
+                                {filteredTAs.length}
                             </div>
                             <div className="Most-Crowded-Box">
                                 {busiestSessionInfo && (

--- a/src/components/pages/ProfessorPeopleView.tsx
+++ b/src/components/pages/ProfessorPeopleView.tsx
@@ -262,13 +262,15 @@ const ProfessorPeopleView = (props: RouteComponentProps<{ courseId: string }>) =
                                 <div className="Most-Crowded-Box">
                                     <div className="most-crowded-text">
                                         <p className="crown-title">TA Performance</p>
-                                        {selectedTA ?
-                                            (<div>
-                                                <p className="maroon-date">{selectedTA.firstName} {selectedTA.lastName}</p>
-                                                <p className="maroon-descript">{selectedTA.email}</p>
-                                            </div>) :
-                                            (<p className="maroon-date">Select a TA</p>)
-                                        }
+                                        <div className="ta-info">
+                                            {selectedTA ?
+                                                (<div>
+                                                    <p className="maroon-date">{selectedTA.firstName} {selectedTA.lastName}</p>
+                                                    <p className="maroon-descript">{selectedTA.email}</p>
+                                                </div>) :
+                                                (<p className="maroon-date">Select a TA</p>)
+                                            }
+                                        </div>
                                         <input
                                             placeholder={"Enter TA Name"}
                                             onChange={(e) => setTAName(e.target.value.toLowerCase())}

--- a/src/components/pages/ProfessorPeopleView.tsx
+++ b/src/components/pages/ProfessorPeopleView.tsx
@@ -4,6 +4,7 @@ import moment from "moment";
 import { DateRangePicker } from "react-dates";
 import { BarDatum } from "@nivo/bar";
 // import QuestionsBarChart from "../includes/QuestionsBarChart";
+import { ConversationList } from "twilio/lib/rest/conversations/v1/conversation";
 import QuestionsBarGraph from "../includes/QuestionsBarGraph";
 import ProfessorSidebar from "../includes/ProfessorSidebar";
 import QuestionsPieChart from "../includes/QuestionsPieChart";
@@ -44,6 +45,7 @@ const ProfessorPeopleView = (props: RouteComponentProps<{ courseId: string }>) =
     const [filteredTAs, setFilteredTAs] = useState<FireUser[]>([])
     const [TAName, setTAName] = useState("")
     const [selectedTA, setSelectedTA] = useState<FireUser>()
+    const [showTADropdown, setShowTADropdown] = useState(false)
 
     useEffect(() => {
         if (TAName.length !== 0) {
@@ -51,7 +53,7 @@ const ProfessorPeopleView = (props: RouteComponentProps<{ courseId: string }>) =
                 ta && ta.email.toLowerCase().startsWith(TAName))
             setFilteredTAs(filtered)
         } else {
-            setFilteredTAs(allTAs)
+            setFilteredTAs([])
         }
     }, [TAName]);
 
@@ -168,7 +170,6 @@ const ProfessorPeopleView = (props: RouteComponentProps<{ courseId: string }>) =
     }
 
     // TA Chart
-    // const taQuestions = questions.flat().filter((q) => q.answererId === "jm0cHTzzw5Xejn2vLYmaoTY1Olq1")
     let taChartYMax = (questions[busiestSessionIndex] && questions[busiestSessionIndex].length) || 0;
 
     if (sessions.length === 0) {
@@ -334,12 +335,15 @@ const ProfessorPeopleView = (props: RouteComponentProps<{ courseId: string }>) =
                                     <input
                                         placeholder={"Enter TA NetID"}
                                         onChange={(e) => setTAName(e.target.value.toLowerCase())}
+                                        onFocus={(e) => setShowTADropdown(true)}
+                                        onBlur={(e) => setShowTADropdown(false)}
                                     />
-                                    <div className="ta-results">
-                                        {filteredTAs.map((ta) => (
-                                            <button type="button" className="ta-result" onClick={e => setSelectedTA(ta)}>{ta.firstName} {ta.lastName} ({ta.email.split("@")[0]})</button>
-                                        ))}
-                                    </div>
+                                    {showTADropdown && filteredTAs.length !== 0 &&
+                                        (<div className="ta-results">
+                                            {filteredTAs.map((ta) => (
+                                                <button type="button" className="ta-result" onMouseDown={e => { setSelectedTA(ta) }}>{ta.firstName} {ta.lastName} ({ta.email.split("@")[0]})</button>
+                                            ))}
+                                        </div>)}
                                 </div>
                                 <div className="questions-line-container">
                                     <QuestionsBarGraph

--- a/src/styles/professor/ProfessorPeopleView.scss
+++ b/src/styles/professor/ProfessorPeopleView.scss
@@ -70,23 +70,51 @@
       width: 90%;
     }
 
-    .ta-results::-webkit-scrollbar {
+    .most-crowded-text {
+      width: 30% !important;
+    }
+
+    .ta-info {
+      min-height: 30%;
+    }
+
+    input {
+      border-radius: 6px;
+      padding-left: 15px;
+      padding-right: 15px;
+      width: 100%;
+      height: 32px;
+    }
+
+    .ta-results::-webkit-scrollbar:horizontal {
       display: none;
     }
 
     .ta-results {
       margin-top: 5px;
-      // background-color: grey;
+      // background-color: blue;
       text-align: left;
-      height: 60%;
-      overflow: scroll;
+      // max-height: 60%;
+      max-height: 70px;
+      overflow: auto;
+      // border-style: solid;
+      // border-color: rgba(0, 0, 0, .87);
+      // border-width: 0.5px;
+      border-radius: 6px;
+      width: 100%;
+      box-shadow: 1px 1px 1px 1px rgba(10, 10, 10, 0.3);
 
       .ta-result {
         text-align: left;
-        padding-top: 5px;
-        padding-bottom: 5px;
+        padding: 10px 15px 10px 15px;
         width: 100%;
-        // background-color: red;
+        color: rgba(0, 0, 0, .87);
+        // border-style: solid;
+        border-width: 0 0 0.5px 0;
+      }
+
+      .ta-result:hover {
+        background-color: #e4efff;
       }
     }
   }

--- a/src/styles/professor/ProfessorPeopleView.scss
+++ b/src/styles/professor/ProfessorPeopleView.scss
@@ -1,128 +1,185 @@
-.ProfessorView{
+.ProfessorView {
 
-    .DateInput_input__focused {
-        border-bottom: 2px solid $brand-primary;
-    }
-    .CalendarDay__selected {
-        background: $tag-blue;
-        border-color: $tag-blue;
-    }
+  .DateInput_input__focused {
+    border-bottom: 2px solid $brand-primary;
+  }
 
-    .CalendarDay__selected_span {
-        background: $brand-primary;
-        border-color: $tag-blue;
-    }
+  .CalendarDay__selected {
+    background: $tag-blue;
+    border-color: $tag-blue;
+  }
 
-    .CalendarDay__hovered_span, .CalendarDay__hovered_span:hover {
-        background: #e4efff;
-        border: 1px double #d0def5;
-        color: #355372;
-    }
+  .CalendarDay__selected_span {
+    background: $brand-primary;
+    border-color: $tag-blue;
+  }
 
-    .CalendarMonth_caption {
-        padding-bottom: 52px;
-    }
+  .CalendarDay__hovered_span,
+  .CalendarDay__hovered_span:hover {
+    background: #e4efff;
+    border: 1px double #d0def5;
+    color: #355372;
+  }
 
-    //Datepicker CSS
-  .Date-picker-container{
+  .CalendarMonth_caption {
+    padding-bottom: 52px;
+  }
+
+  //Datepicker CSS
+  .Date-picker-container {
     width: 286px;
     margin-top: 15px;
   }
+
   .react-datepicker-popper {
     left: 20px !important;
   }
-  .react-datepicker__time-container .react-datepicker__time .react-datepicker__time-box ul.react-datepicker__time-list {
-      padding-right: 0;
-      text-align: center;
 
-      li.react-datepicker__time-list-item {
-          padding: 5px 0;
-      }
+  .react-datepicker__time-container .react-datepicker__time .react-datepicker__time-box ul.react-datepicker__time-list {
+    padding-right: 0;
+    text-align: center;
+
+    li.react-datepicker__time-list-item {
+      padding: 5px 0;
+    }
   }
+
   //End Datepicker CSS
-  .first-row-container{
-    display:flex;
+
+  .first-row-container::-webkit-scrollbar {
+    display: none;
+  }
+
+  .first-row-container {
+    display: flex;
     margin-top: 15px;
-    .questions-bar-container{
+    justify-content: space-between;
+    overflow-x: scroll;
+
+    .questions-bar-container {
       width: 80%;
       background-color: white;
       border-radius: 6px;
       margin-left: 15px;
       padding: 40px 20px 20px 20px;
     }
+
+    .Most-Crowded-Box {
+      margin-top: 0px;
+      margin-left: 15px;
+      width: 90%;
+    }
+
+    .ta-results::-webkit-scrollbar {
+      display: none;
+    }
+
+    .ta-results {
+      margin-top: 5px;
+      // background-color: grey;
+      text-align: left;
+      height: 60%;
+      overflow: scroll;
+
+      .ta-result {
+        text-align: left;
+        padding-top: 5px;
+        padding-bottom: 5px;
+        width: 100%;
+        // background-color: red;
+      }
+    }
   }
-  .Total-Questions-Box{
+
+  .Total-Questions-Box {
     height: 360px;
     background-color: white;
     border-radius: 6px;
     width: 20%;
     padding-bottom: 20px;
-    .percent-overlay{
+
+    .percent-overlay {
       margin-top: -165px;
     }
-    .Question-Number{
+
+    .Question-Number {
       font-size: 45px;
       color: #a8c7eb;
     }
-    .Question-Percent{
+
+    .Question-Percent {
       font-size: 45px;
       color: #a8c7eb;
     }
-    .q-total-container{
+
+    .q-total-container {
       margin-top: 100px;
     }
   }
-  .Most-Crowded-Box{
+
+  .Most-Crowded-Box {
     display: flex;
     margin-top: 15px;
     background-color: white;
     border-radius: 6px;
     padding: 20px;
-    .most-crowded-text{
+
+    .most-crowded-text {
       width: 20%;
       text-align: left;
-      .crowd-title{
+
+      .crowd-title {
         font-size: 15px;
       }
-      .maroon-date{
+
+      .maroon-date {
         color: #933131;
         font-size: 20px;
       }
-      .maroon-descript{
+
+      .maroon-descript {
         color: #933131;
         margin-bottom: 1px;
         font-size: 15xpx;
       }
-      hr{
+
+      hr {
         margin: 24px 0px;
       }
     }
-  .questions-line-container{
-    width: 80%;
-  }
+
+    .questions-line-container {
+      width: 80%;
+    }
   }
 }
-.bar-tooltip{
+
+.bar-tooltip {
   color: white;
   font-size: 12px;
   padding: 3px 0px;
   letter-spacing: 1px;
-  .tooltip-section{
+
+  .tooltip-section {
     padding-left: 10px;
     text-align: left;
   }
-  .tooltip-nums{
+
+  .tooltip-nums {
     text-align: center;
     display: flex;
-    .tool-flex{
+
+    .tool-flex {
       margin-left: 10px;
-      .tool-stat{
+
+      .tool-stat {
         font-size: 13px;
       }
     }
   }
 }
-.no-question-warning{
+
+.no-question-warning {
   margin-top: 50px;
   margin-bottom: 200px;
   background-color: white;

--- a/src/styles/professor/ProfessorPeopleView.scss
+++ b/src/styles/professor/ProfessorPeopleView.scss
@@ -69,53 +69,49 @@
       margin-left: 15px;
       width: 90%;
     }
+  }
 
-    .most-crowded-text {
-      width: 30% !important;
-    }
+  .ta-info {
+    min-height: 32%;
+  }
 
-    .ta-info {
-      min-height: 30%;
-    }
+  input {
+    border-radius: 6px;
+    padding-left: 15px;
+    padding-right: 15px;
+    width: 100%;
+    height: 35px;
+  }
 
-    input {
-      border-radius: 6px;
-      padding-left: 15px;
-      padding-right: 15px;
-      width: 100%;
-      height: 32px;
-    }
+  .ta-results::-webkit-scrollbar:horizontal {
+    display: none;
+  }
 
-    .ta-results::-webkit-scrollbar:horizontal {
-      display: none;
-    }
+  .ta-results {
+    margin-top: 5px;
+    // background-color: blue;
+    text-align: left;
+    // max-height: 60%;
+    max-height: 70px;
+    overflow: auto;
+    // border-style: solid;
+    // border-color: rgba(0, 0, 0, .87);
+    // border-width: 0.5px;
+    border-radius: 6px;
+    width: 100%;
+    box-shadow: 1px 1px 1px 1px #e1e2e3;
 
-    .ta-results {
-      margin-top: 5px;
-      // background-color: blue;
+    .ta-result {
       text-align: left;
-      // max-height: 60%;
-      max-height: 70px;
-      overflow: auto;
-      // border-style: solid;
-      // border-color: rgba(0, 0, 0, .87);
-      // border-width: 0.5px;
-      border-radius: 6px;
+      padding: 10px 15px 10px 15px;
       width: 100%;
-      box-shadow: 1px 1px 1px 1px rgba(10, 10, 10, 0.3);
+      color: rgba(0, 0, 0, .87);
+      // border-style: solid;
+      border-width: 0 0 0.5px 0;
+    }
 
-      .ta-result {
-        text-align: left;
-        padding: 10px 15px 10px 15px;
-        width: 100%;
-        color: rgba(0, 0, 0, .87);
-        // border-style: solid;
-        border-width: 0 0 0.5px 0;
-      }
-
-      .ta-result:hover {
-        background-color: #e4efff;
-      }
+    .ta-result:hover {
+      background-color: #e4efff;
     }
   }
 

--- a/src/styles/professor/ProfessorPeopleView.scss
+++ b/src/styles/professor/ProfessorPeopleView.scss
@@ -77,10 +77,7 @@
 
   input {
     border-radius: 6px;
-    padding-left: 15px;
-    padding-right: 15px;
     width: 100%;
-    height: 35px;
   }
 
   .ta-results::-webkit-scrollbar:horizontal {
@@ -89,24 +86,18 @@
 
   .ta-results {
     margin-top: 5px;
-    // background-color: blue;
     text-align: left;
-    // max-height: 60%;
-    max-height: 70px;
+    max-height: 50%;
     overflow: auto;
-    // border-style: solid;
-    // border-color: rgba(0, 0, 0, .87);
-    // border-width: 0.5px;
     border-radius: 6px;
     width: 100%;
     box-shadow: 1px 1px 1px 1px #e1e2e3;
 
     .ta-result {
       text-align: left;
-      padding: 10px 15px 10px 15px;
+      padding: 10px 10px 10px 10px;
       width: 100%;
       color: rgba(0, 0, 0, .87);
-      // border-style: solid;
       border-width: 0 0 0.5px 0;
     }
 


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->

<!-- Add your summary here -->

This PR adds a graph to the professor analytics page to display the number of questions answered by each TA. Based on our discussion during standup, I moved the wait time graph to the top and added the TA graph to the bottom of the page as shown below. 
 
<img width="400" alt="Screen Shot 2023-03-04 at 8 55 43 PM" src="https://user-images.githubusercontent.com/82056699/222937630-900fa0b9-2d72-42d1-b82a-2aa04c159884.png"> <img width="400" alt="Screen Shot 2023-03-04 at 8 55 55 PM" src="https://user-images.githubusercontent.com/82056699/222937635-b736ef7c-5e63-4762-bb59-7718f6132fa2.png">

Initially, the graph is empty since no TA has been selected.

<img width="1156" alt="Screen Shot 2023-03-04 at 8 56 07 PM" src="https://user-images.githubusercontent.com/82056699/222937709-0fad1f1b-f604-448e-8832-610373d0e041.png">

The professor can search for TAs by NetID. When the professor types in a sequence of characters, all students with NetIDs that begin with that sequence of characters will be displayed in a dropdown. The professor can scroll through and hover over names in the dropdown. 

<img width="1158" alt="Screen Shot 2023-03-04 at 8 56 33 PM" src="https://user-images.githubusercontent.com/82056699/222937741-92eadb58-6e5b-4403-bb54-13e3c46ed18b.png">

Once the professor clicks on a TA, the graph will display the questions answered by the TA during the date range selected. 

<img width="1158" alt="Screen Shot 2023-03-04 at 8 57 57 PM" src="https://user-images.githubusercontent.com/82056699/222937770-0514778d-2c2a-465b-a7d9-753d2ce7b156.png">

Like the Most Crowded graph, different office hour session on the same day will be shown as separate sections of the same bar. 

<img width="1156" alt="Screen Shot 2023-03-04 at 9 08 44 PM" src="https://user-images.githubusercontent.com/82056699/222937822-bcf56313-ef84-4cab-b820-745b60960660.png">



<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->
- [ ] Check that questions answered are displayed correctly for TAs across calendar date range and for days with multiple office hour sessions. When a different TA is selected, the graph data and TA info on the left should update. 
- [ ] Check that all TAs that have answered questions in the date range can be found through NetID. 
- [ ] Check that dropdown scrolls for a long list of TAs.
- [ ] Check that TA cell is blue when hovered over.
- [ ] Check that dropdown closes when a TA is selected or click outside.

<!-- Briefly describe how you test you changes. -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
