### PR TITLE
Add office hours calendar dots

### DIFF
--- a/src/components/includes/CalendarDateItem.tsx
+++ b/src/components/includes/CalendarDateItem.tsx
@@ -7,8 +7,8 @@ type Props = {
     day: string;
     date: number;
     handleClick: Function;
-    numSessions: number;
-    activeSession: number;
+    hasSession: boolean;
+    activeSession: boolean;
 };
 
 class CalendarDateItem extends React.PureComponent<Props> {
@@ -22,7 +22,7 @@ class CalendarDateItem extends React.PureComponent<Props> {
                 <div className="day">{this.props.day}</div>
                 <div className="date">{this.props.date}</div>
                 <div className="indicator">
-                    {this.props.numSessions - this.props.activeSession !== 0 && 
+                    {this.props.hasSession && !this.props.activeSession && 
                         <img src={sessionIndicator} alt="session indicator" />}
                 </div>
             </button>

--- a/src/components/includes/CalendarDateItem.tsx
+++ b/src/components/includes/CalendarDateItem.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import notif from '../../media/notif.svg'
+import sessionIndicator from '../../media/sessionIndicator.svg'
 
 type Props = {
     index: number;
@@ -7,7 +7,8 @@ type Props = {
     day: string;
     date: number;
     handleClick: Function;
-    hasSession: boolean;
+    numSessions: number;
+    activeSession: number;
 };
 
 class CalendarDateItem extends React.PureComponent<Props> {
@@ -19,11 +20,11 @@ class CalendarDateItem extends React.PureComponent<Props> {
         return (
             <button type="button" className={'menuDate' + (this.props.active ? ' active' : '')} onClick={this._onClick}>
                 <div className="day">{this.props.day}</div>
-                <div className="notifications__calendar">
-                    {this.props.hasSession && 
-                        <img className="notifications__indicator" src={notif} alt="Notification indicator" />}
-                </div>
                 <div className="date">{this.props.date}</div>
+                <div className="indicator">
+                    {this.props.numSessions - this.props.activeSession !== 0 && 
+                        <img src={sessionIndicator} alt="session indicator" />}
+                </div>
             </button>
         );
     }

--- a/src/components/includes/CalendarDateItem.tsx
+++ b/src/components/includes/CalendarDateItem.tsx
@@ -8,7 +8,6 @@ type Props = {
     date: number;
     handleClick: Function;
     hasSession: boolean;
-    activeSession: boolean;
 };
 
 class CalendarDateItem extends React.PureComponent<Props> {
@@ -22,7 +21,7 @@ class CalendarDateItem extends React.PureComponent<Props> {
                 <div className="day">{this.props.day}</div>
                 <div className="date">{this.props.date}</div>
                 <div className="indicator">
-                    {this.props.hasSession && !this.props.activeSession && 
+                    {this.props.hasSession && !this.props.active && 
                         <img src={sessionIndicator} alt="session indicator" />}
                 </div>
             </button>

--- a/src/components/includes/CalendarDateItem.tsx
+++ b/src/components/includes/CalendarDateItem.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import notif from '../../media/notif.svg'
 
 type Props = {
     index: number;
@@ -6,6 +7,7 @@ type Props = {
     day: string;
     date: number;
     handleClick: Function;
+    hasSession: boolean;
 };
 
 class CalendarDateItem extends React.PureComponent<Props> {
@@ -17,6 +19,10 @@ class CalendarDateItem extends React.PureComponent<Props> {
         return (
             <button type="button" className={'menuDate' + (this.props.active ? ' active' : '')} onClick={this._onClick}>
                 <div className="day">{this.props.day}</div>
+                <div className="notifications__calendar">
+                    {this.props.hasSession && 
+                        <img className="notifications__indicator" src={notif} alt="Notification indicator" />}
+                </div>
                 <div className="date">{this.props.date}</div>
             </button>
         );

--- a/src/components/includes/CalendarDaySelect.tsx
+++ b/src/components/includes/CalendarDaySelect.tsx
@@ -12,7 +12,6 @@ const monthNames = ['January', 'February', 'March', 'April', 'May', 'June',
 type Props = { 
     callback: (time: number) => void; 
     sessionDates: Date[];
-    activeSessionDay: number | undefined;
 };
 
 const CalendarDaySelect: React.FC<Props> = (props) => {
@@ -57,11 +56,6 @@ const CalendarDaySelect: React.FC<Props> = (props) => {
         hasSessionsDays[((d - 1) + 7) % 7] = true;
     }
 
-    const activeSessionDays = new Array(7);
-    if (props.activeSessionDay !== undefined) {
-        activeSessionDays[((props.activeSessionDay - 1) + 7) % 7] = true;
-    }
-
     return (
         <div className="CalendarDaySelect">
             <p className="month">{monthNames[now.getMonth()]}</p>
@@ -81,7 +75,6 @@ const CalendarDaySelect: React.FC<Props> = (props) => {
                     active={i === active}
                     handleClick={handleDateClick}
                     hasSession={hasSessionsDays[i]}
-                    activeSession={activeSessionDays[i]}
                 />)}
                 <button type="button" className="NextWeek" onClick={() => incrementWeek(true)}>
                     <img src={chevron} alt="Next Week" />

--- a/src/components/includes/CalendarDaySelect.tsx
+++ b/src/components/includes/CalendarDaySelect.tsx
@@ -12,6 +12,7 @@ const monthNames = ['January', 'February', 'March', 'April', 'May', 'June',
 type Props = { 
     callback: (time: number) => void; 
     sessionDates: Date[];
+    activeSessionDay: number | undefined;
 };
 
 const CalendarDaySelect: React.FC<Props> = (props) => {
@@ -48,12 +49,17 @@ const CalendarDaySelect: React.FC<Props> = (props) => {
 
     const now = new Date(selectedWeekEpoch);
 
-    const hasSessionDays = new Array(7);
+    const numSessionsDays = new Array(7).fill(0);
     const sessionDays = props.sessionDates
         .filter((d) => d.getTime() >= selectedWeekEpoch && d.getTime() <= selectedWeekEpoch + ONE_WEEK)
         .map((d) => d.getDay());
     for (const d of sessionDays) {
-        hasSessionDays[((d - 1) + 7) % 7] = true;
+        numSessionsDays[((d - 1) + 7) % 7] += 1;
+    }
+
+    const activeSessionDays = new Array(7).fill(0);
+    if (props.activeSessionDay !== undefined) {
+        activeSessionDays[((props.activeSessionDay - 1) + 7) % 7] = 1;
     }
 
     return (
@@ -74,7 +80,8 @@ const CalendarDaySelect: React.FC<Props> = (props) => {
                     date={new Date(now.getTime() + i * ONE_DAY).getDate()}
                     active={i === active}
                     handleClick={handleDateClick}
-                    hasSession={hasSessionDays[i]}
+                    numSessions={numSessionsDays[i]}
+                    activeSession={activeSessionDays[i]}
                 />)}
                 <button type="button" className="NextWeek" onClick={() => incrementWeek(true)}>
                     <img src={chevron} alt="Next Week" />

--- a/src/components/includes/CalendarDaySelect.tsx
+++ b/src/components/includes/CalendarDaySelect.tsx
@@ -49,17 +49,17 @@ const CalendarDaySelect: React.FC<Props> = (props) => {
 
     const now = new Date(selectedWeekEpoch);
 
-    const numSessionsDays = new Array(7).fill(0);
+    const hasSessionsDays = new Array(7);
     const sessionDays = props.sessionDates
         .filter((d) => d.getTime() >= selectedWeekEpoch && d.getTime() <= selectedWeekEpoch + ONE_WEEK)
         .map((d) => d.getDay());
     for (const d of sessionDays) {
-        numSessionsDays[((d - 1) + 7) % 7] += 1;
+        hasSessionsDays[((d - 1) + 7) % 7] = true;
     }
 
-    const activeSessionDays = new Array(7).fill(0);
+    const activeSessionDays = new Array(7);
     if (props.activeSessionDay !== undefined) {
-        activeSessionDays[((props.activeSessionDay - 1) + 7) % 7] = 1;
+        activeSessionDays[((props.activeSessionDay - 1) + 7) % 7] = true;
     }
 
     return (
@@ -80,7 +80,7 @@ const CalendarDaySelect: React.FC<Props> = (props) => {
                     date={new Date(now.getTime() + i * ONE_DAY).getDate()}
                     active={i === active}
                     handleClick={handleDateClick}
-                    numSessions={numSessionsDays[i]}
+                    hasSession={hasSessionsDays[i]}
                     activeSession={activeSessionDays[i]}
                 />)}
                 <button type="button" className="NextWeek" onClick={() => incrementWeek(true)}>

--- a/src/components/includes/CalendarDaySelect.tsx
+++ b/src/components/includes/CalendarDaySelect.tsx
@@ -9,7 +9,10 @@ const dayList = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 const monthNames = ['January', 'February', 'March', 'April', 'May', 'June',
     'July', 'August', 'September', 'October', 'November', 'December'];
 
-type Props = { callback: (time: number) => void };
+type Props = { 
+    callback: (time: number) => void; 
+    sessionDates: Date[];
+};
 
 const CalendarDaySelect: React.FC<Props> = (props) => {
     const { callback } = props;
@@ -44,6 +47,15 @@ const CalendarDaySelect: React.FC<Props> = (props) => {
     }, [callback, selectedWeekEpoch]);
 
     const now = new Date(selectedWeekEpoch);
+
+    const hasSessionDays = new Array(7);
+    const sessionDays = props.sessionDates
+        .filter((d) => d.getTime() >= selectedWeekEpoch && d.getTime() <= selectedWeekEpoch + ONE_WEEK)
+        .map((d) => d.getDay());
+    for (const d of sessionDays) {
+        hasSessionDays[((d - 1) + 7) % 7] = true;
+    }
+
     return (
         <div className="CalendarDaySelect">
             <p className="month">{monthNames[now.getMonth()]}</p>
@@ -62,6 +74,7 @@ const CalendarDaySelect: React.FC<Props> = (props) => {
                     date={new Date(now.getTime() + i * ONE_DAY).getDate()}
                     active={i === active}
                     handleClick={handleDateClick}
+                    hasSession={hasSessionDays[i]}
                 />)}
                 <button type="button" className="NextWeek" onClick={() => incrementWeek(true)}>
                     <img src={chevron} alt="Next Week" />

--- a/src/components/includes/CalendarView.tsx
+++ b/src/components/includes/CalendarView.tsx
@@ -69,7 +69,6 @@ const CalenderView = ({
             <CalendarDaySelect 
                 callback={setSelectedDate} 
                 sessionDates={sessionDates} 
-                activeSessionDay={isActiveSession? session?.startTime.toDate().getDay() : undefined} 
             />
             {course && user && sessions ? (
                 <CalendarSessions

--- a/src/components/includes/CalendarView.tsx
+++ b/src/components/includes/CalendarView.tsx
@@ -66,7 +66,11 @@ const CalenderView = ({
 
     return (
         <aside className='CalendarView'>
-            <CalendarDaySelect callback={setSelectedDate} sessionDates={sessionDates} />
+            <CalendarDaySelect 
+                callback={setSelectedDate} 
+                sessionDates={sessionDates} 
+                activeSessionDay={isActiveSession? session?.startTime.toDate().getDay() : undefined} 
+            />
             {course && user && sessions ? (
                 <CalendarSessions
                     activeSession={isActiveSession? session : undefined}

--- a/src/components/includes/CalendarView.tsx
+++ b/src/components/includes/CalendarView.tsx
@@ -61,10 +61,12 @@ const CalenderView = ({
             const bStart = b.startTime;
             return aStart.toDate().getTime() - bStart.toDate().getTime();
         });
+    
+    const sessionDates = sessions === null ? [] : sessions.map((s) => s.startTime.toDate());
 
     return (
         <aside className='CalendarView'>
-            <CalendarDaySelect callback={setSelectedDate} />
+            <CalendarDaySelect callback={setSelectedDate} sessionDates={sessionDates} />
             {course && user && sessions ? (
                 <CalendarSessions
                     activeSession={isActiveSession? session : undefined}

--- a/src/media/sessionIndicator.svg
+++ b/src/media/sessionIndicator.svg
@@ -1,0 +1,3 @@
+<svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="4" cy="4" r="4" fill="#ADADAD"/>
+</svg>

--- a/src/styles/blogPosts/Notifications.scss
+++ b/src/styles/blogPosts/Notifications.scss
@@ -10,11 +10,6 @@
         flex-direction: column;
         align-items: center;
     }
-    &__calendar {
-        position: relative;
-        margin-left: 2px;
-        padding-bottom: 1px;
-    }
     &__dropdown {
         position: absolute;
         z-index: 100;

--- a/src/styles/blogPosts/Notifications.scss
+++ b/src/styles/blogPosts/Notifications.scss
@@ -10,6 +10,11 @@
         flex-direction: column;
         align-items: center;
     }
+    &__calendar {
+        position: relative;
+        margin-left: 2px;
+        padding-bottom: 1px;
+    }
     &__dropdown {
         position: absolute;
         z-index: 100;

--- a/src/styles/calendar/CalendarDaySelect.scss
+++ b/src/styles/calendar/CalendarDaySelect.scss
@@ -38,6 +38,7 @@ $red: #f67d7d;
     background-color: #fcd9d9;
     border-radius: 50%;
     margin: auto;
+    margin-left: -2px;
     height: 30px;
     width: 30px;
 }
@@ -48,7 +49,7 @@ $red: #f67d7d;
 
 .menuDate {
     cursor: pointer;
-    height: 54px;
+    height: 64px;
     width: 30px;
     background-color: transparent;
     border-color: transparent;
@@ -62,6 +63,7 @@ $red: #f67d7d;
             background-color: $red;
             border-radius: 50%;
             margin: auto;
+            margin-left: -2px;
             height: 30px;
             width: 30px;
         }
@@ -76,6 +78,10 @@ $red: #f67d7d;
     &>.date {
         font-size: 15px;
         padding: 6px 0px;
+    }
+
+    &>.indicator {
+        height: 15px;
     }
 
     &>.notification {


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->

Adds gray dot below all days with office hours on calendar. Dot under day becomes invisible if that day is clicked, dot becomes visible again if a different day is clicked.

<img width="1434" alt="Screen Shot 2023-03-15 at 5 25 36 PM" src="https://user-images.githubusercontent.com/45403687/225447674-03316d83-de93-4fe1-a990-90f45eb2afc6.png">

<img width="1429" alt="Screen Shot 2023-03-15 at 5 25 57 PM" src="https://user-images.githubusercontent.com/45403687/225447686-e26e8c0b-0beb-497d-8432-5503993b58f3.png">

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->

Made test office hours and tested clicking through days of the calendar.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
