### PR TITLE
Fixed Notifications Menu Bug

### DIFF
--- a/src/components/includes/TopBar.tsx
+++ b/src/components/includes/TopBar.tsx
@@ -99,7 +99,7 @@ const TopBar = (props: Props) => {
                         )}
                     </div>
                     <div className="rightContentWrapper" >
-                        <TopBarNotifications notificationTracker={notificationTracker} />
+                        <TopBarNotifications notificationTracker={notificationTracker} iconClick={() => setShowMenu(!showMenu)} showMenu = {showMenu}/>
                         <div className="userProfile" onClick={() => setShowMenu(!showMenu)}>
                             <img
                                 src={image}

--- a/src/components/includes/TopBar.tsx
+++ b/src/components/includes/TopBar.tsx
@@ -99,7 +99,8 @@ const TopBar = (props: Props) => {
                         )}
                     </div>
                     <div className="rightContentWrapper" >
-                        <TopBarNotifications notificationTracker={notificationTracker} iconClick={() => setShowMenu(!showMenu)} showMenu = {showMenu}/>
+                        <TopBarNotifications notificationTracker={notificationTracker} 
+                         iconClick={() => setShowMenu(!showMenu)} showMenu={showMenu}/>
                         <div className="userProfile" onClick={() => setShowMenu(!showMenu)}>
                             <img
                                 src={image}

--- a/src/components/includes/TopBar.tsx
+++ b/src/components/includes/TopBar.tsx
@@ -99,8 +99,11 @@ const TopBar = (props: Props) => {
                         )}
                     </div>
                     <div className="rightContentWrapper" >
-                        <TopBarNotifications notificationTracker={notificationTracker} 
-                         iconClick={() => setShowMenu(!showMenu)} showMenu={showMenu}/>
+                        <TopBarNotifications 
+                            notificationTracker={notificationTracker} 
+                            iconClick={() => setShowMenu(!showMenu)} 
+                            showMenu={showMenu}
+                        />
                         <div className="userProfile" onClick={() => setShowMenu(!showMenu)}>
                             <img
                                 src={image}

--- a/src/components/includes/TopBarNotifications.tsx
+++ b/src/components/includes/TopBarNotifications.tsx
@@ -7,11 +7,17 @@ import {viewedTrackable, periodicClearNotifications} from '../../firebasefunctio
 import { RootState } from '../../redux/store';
 
 type Props = {
+    /** Notification Tracker keeps track of the list of notifications for a user */
     notificationTracker: NotificationTracker | undefined;
+    /** User that is currently using QMI */
     user: FireUser | undefined;
+    /** Function that sets showMenu to false or true */
+    iconClick: Function;
+    /** Determines whether the profile menu should be shown or not */
+    showMenu: boolean;
 }
 
-const TopBarNotifications = ({notificationTracker, user}: Props) => {
+const TopBarNotifications = ({notificationTracker, user, showMenu, iconClick}: Props) => {
     const [dropped, toggleDropped] = useState(false);
 
     const notifications = notificationTracker?.notificationList?.sort((a, b) => {
@@ -65,7 +71,10 @@ const TopBarNotifications = ({notificationTracker, user}: Props) => {
     })
 
     const iconClicked = () => {
-        if(dropped) {
+        if (showMenu) {
+            iconClick();
+        }
+        if (dropped) {
             updateTrackable();
         }
         toggleDropped(!dropped);


### PR DESCRIPTION
### Summary <!-- Required -->

Fixed bug where the notifications menu would be hidden behind profile menu if profile menu was open before the notifications icon was clicked. Now, the menus switch if the different buttons are clicked in any order. Passed the showMenu variable and the function to change it down to the TopBarNotifications component.

### Test Plan <!-- Required -->

Tested by running the website and clicking the notifications icon and the profile icon in different ways multiple times.

### Checklist

- [ x ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
