### PR TITLE
Collapse former classes

### DIFF
--- a/src/components/includes/CourseSelection.tsx
+++ b/src/components/includes/CourseSelection.tsx
@@ -56,7 +56,7 @@ function CourseSelection({ user, isEdit, allCourses }: Props): React.ReactElemen
 
     const [selectedCourseIds, setSelectedCourseIds] = useState<string[]>([]);
 
-    const [collapsed, setCollapsed] = useState(false);
+    const [collapsed, setCollapsed] = useState(true);
 
     const coursesToEnroll: string[] = [];
     const coursesToUnenroll: string[] = [];

--- a/src/components/includes/CourseSelection.tsx
+++ b/src/components/includes/CourseSelection.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router';
 
 import { connect } from 'react-redux';
+import { Icon } from 'semantic-ui-react'
 import TopBar from './TopBar';
 import CourseCard from './CourseCard';
 import { CURRENT_SEMESTER } from '../../constants';
@@ -54,6 +55,8 @@ function CourseSelection({ user, isEdit, allCourses }: Props): React.ReactElemen
     }, [user, currentCourses, currentlyEnrolledCourseIds]);
 
     const [selectedCourseIds, setSelectedCourseIds] = useState<string[]>([]);
+
+    const [collapsed, setCollapsed] = useState(false);
 
     const coursesToEnroll: string[] = [];
     const coursesToUnenroll: string[] = [];
@@ -158,14 +161,14 @@ function CourseSelection({ user, isEdit, allCourses }: Props): React.ReactElemen
                             </div>
                             <div className="CourseCards">
                                 {currentCourses.filter(course => selectedCourseIds.includes(course.courseId) ||
-                            currentlyEnrolledCourseIds.has(course.courseId)
-                            || isEdit)
+                                    currentlyEnrolledCourseIds.has(course.courseId)
+                                    || isEdit)
                                     .map((course) => {
                                         const role = currentlyEnrolledCourseIds.has(course.courseId)
                                             ? (user.roles[course.courseId] || 'student')
                                             : undefined;
                                         const selected = selectedCourseIds.includes(course.courseId)
-                                    || (role !== undefined && role !== 'student');
+                                            || (role !== undefined && role !== 'student');
                                         return (
                                             <div key={course.courseId}>
                                                 <CourseCard
@@ -192,10 +195,21 @@ function CourseSelection({ user, isEdit, allCourses }: Props): React.ReactElemen
                         <div className="description">
                             <div className="subtitle">
                                 Former Classes
+                                {collapsed ? (
+                                    <Icon
+                                        name='chevron down'
+                                        onClick={() => { setCollapsed(false) }}
+                                    />
+                                ) : (
+                                    <Icon
+                                        name='chevron up'
+                                        onClick={() => setCollapsed(true)}
+                                    />
+                                )}
                             </div>
                         </div>
                         <div className="CourseCards CourseCardsInactive">
-                            {formerCourses.filter(course => selectedCourseIds.includes(course.courseId) ||
+                            {!collapsed && formerCourses.filter(course => selectedCourseIds.includes(course.courseId) ||
                                 currentlyEnrolledCourseIds.has(course.courseId))
                                 .map((course, index) => {
                                     const role = currentlyEnrolledCourseIds.has(course.courseId)
@@ -250,7 +264,7 @@ function CourseSelection({ user, isEdit, allCourses }: Props): React.ReactElemen
     );
 }
 const mapStateToProps = (state: RootState) => ({
-    user : state.auth.user
+    user: state.auth.user
 })
 
 

--- a/src/firebasefunctions/session.ts
+++ b/src/firebasefunctions/session.ts
@@ -2,7 +2,7 @@ import firebase from 'firebase/app';
 import { firestore } from '../firebase';
 
 export const addSession = (session: Omit<FireSession, 'sessionId'>) => {
-    return firestore.collection('sessions').add(session).then(() => {});
+    return firestore.collection('sessions').add(session).then(() => { });
 }
 
 export const updateSession = (oldSession: FireSession, newSession: Omit<FireSession, 'sessionId'>) => {
@@ -32,34 +32,34 @@ export const getUsersFromSessions = async (sessions: FireSession[]): Promise<Fir
 }
 
 export const addTaAnnouncement = (
-    oldSession: FireSession, 
-    user: FireUser, 
+    oldSession: FireSession,
+    user: FireUser,
     announcement: string) => {
     const taAnnouncement: TaAnnouncement = {
-        ta: user, 
-        announcement, 
+        ta: user,
+        announcement,
         uploadTime: firebase.firestore.Timestamp.now()
     }
     const newSession: FireSession = {
-        ...oldSession, 
-        taAnnouncemements: 
-                oldSession.taAnnouncemements 
-                    ? [taAnnouncement, ...oldSession.taAnnouncemements]
-                    : [taAnnouncement] 
+        ...oldSession,
+        taAnnouncemements:
+            oldSession.taAnnouncemements
+                ? [taAnnouncement, ...oldSession.taAnnouncemements]
+                : [taAnnouncement]
     }
     firestore.collection('sessions').doc(oldSession.sessionId).update(newSession);
 }
 
 export const deleteTaAnnouncement = (
-    oldSession: FireSession, 
-    user: FireUser, 
-    announcement: string, 
+    oldSession: FireSession,
+    user: FireUser,
+    announcement: string,
     uploadTime: FireTimestamp,
 ) => {
     const newTaAnnouncements = oldSession.taAnnouncemements?.filter(
-            a => !((a.ta.userId === user.userId) && (a.announcement === announcement) && (a.uploadTime === uploadTime)))
+        a => !((a.ta.userId === user.userId) && (a.announcement === announcement) && (a.uploadTime === uploadTime)))
     const newSession: FireSession = {
-        ...oldSession, 
+        ...oldSession,
         taAnnouncemements: newTaAnnouncements
     }
     firestore.collection('sessions').doc(oldSession.sessionId).update(newSession);

--- a/src/styles/courses/CourseSelection.scss
+++ b/src/styles/courses/CourseSelection.scss
@@ -27,6 +27,11 @@
                 .EnrolledCourses.mobile {
                     display: none;
                 }
+
+                .icon {
+                    padding-left: 10px;
+                    cursor: pointer;
+                }
             }
         }
 


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
This PR adds functionality to collapse and expand former courses on the classes page. When the page is initially loaded, the former courses default to collapsed. 
<!-- Add your summary here -->
<img width="1501" alt="Screenshot 2023-11-28 at 6 23 13 PM" src="https://github.com/cornell-dti/office-hours/assets/82056699/eb0b3a72-67bf-4844-90a3-6daab902784e">


<img width="1485" alt="Screenshot 2023-11-28 at 6 25 47 PM" src="https://github.com/cornell-dti/office-hours/assets/82056699/89b4783b-a298-4e58-9004-c6cfb9a536ee">


<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->
- [ ] Check that the former courses can be collapsed and expanded by toggling the icon
- [ ] Check that the former courses default to collapsed 

<!-- Briefly describe how you test you changes. -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
