### PR TITLE
Collapsible TA/Professor view

### DIFF
--- a/src/components/includes/AdminReadOnlyCourseCard.tsx
+++ b/src/components/includes/AdminReadOnlyCourseCard.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useCourseProfessorMap, useCourseTAMap } from '../../firehooks';
+import { Icon } from 'semantic-ui-react';
 
 const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) => {
     const professorMap = useCourseProfessorMap(course);
     const taMap = useCourseTAMap(course);
+    const [collapsed, setCollapsed] = useState(true);
 
     return (
         <div>
@@ -20,7 +22,14 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
             </div>
             <div className="course-section">
                 <h3>Professors</h3>
+
+                {collapsed ? (<Icon name='chevron down' onClick={() => { setCollapsed(false) }} />) :
+                    (<Icon name='chevron up' onClick={() => setCollapsed(true)} />)}
+
                 {course.professors.length === 0 && <div>None</div>}
+
+                { /* gotta modify somewhere here*/}
+
                 <ul>
                     {course.professors.map(id => {
                         const professor = professorMap[id];

--- a/src/components/includes/AdminReadOnlyCourseCard.tsx
+++ b/src/components/includes/AdminReadOnlyCourseCard.tsx
@@ -29,9 +29,7 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
                         }
                         return (
                             <li key={id}>
-                                {professor.firstName}
-                                {professor.lastName}
-                                ({professor.email})
+                                {professor.firstName}  {professor.lastName} ({professor.email})
                             </li>
                         );
                     })}
@@ -48,9 +46,7 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
                         }
                         return (
                             <li key={id}>
-                                {ta.firstName} 
-                                {ta.lastName} 
-                                ({ta.email})
+                                {ta.firstName} {ta.lastName} ({ta.email})
                             </li>
                         );
                     })}

--- a/src/components/includes/AdminReadOnlyCourseCard.tsx
+++ b/src/components/includes/AdminReadOnlyCourseCard.tsx
@@ -12,6 +12,13 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
     const profDefaultSize = 2;
     const taDefaultSize = 4;
 
+    /* creates a list for the current professors and tas, displays at most the default size 
+    e.g 2 professors and 4 TAs. 
+        - [list] is an array of professors or tas, 
+        - [roleType] should be either "p" or "t", which indicates whether this 
+        function is for displaying professors or TAs
+        - [defaultSize] is the number of professors or TAs to show by default before the icons appear
+    */
     const displayRoleList = (list: readonly string[], roleType: string, defaultSize: number) => {
 
         if (list.length <= defaultSize) {
@@ -70,6 +77,7 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
 
                 <br />
 
+                {/* Display icon only if the number of professors is greater than the default size */}
                 {course.professors.length > profDefaultSize ?
                     profCollapsed ?
                         (<Icon name='chevron down' onClick={() => { setProfCollapsed(false) }} />) :
@@ -97,7 +105,7 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
                 {displayRoleList(course.tas, "t", taDefaultSize)}
 
                 <br />
-
+                {/* Display icon only if the number of TAs is greater than the default size */}
                 {course.tas.length > taDefaultSize ?
                     taCollapsed ?
                         (<Icon name='chevron down' onClick={() => { setTaCollapsed(false) }} />) :

--- a/src/components/includes/AdminReadOnlyCourseCard.tsx
+++ b/src/components/includes/AdminReadOnlyCourseCard.tsx
@@ -71,16 +71,6 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
                 <h3>Professors</h3>
                 {course.professors.length === 0 && <div>None</div>}
                 {displayRoleList(course.professors, "p", profDefaultSize)}
-
-                <br />
-
-                {/* Display icon only if the number of professors is greater than the default size */}
-                {course.professors.length > profDefaultSize ?
-                    profCollapsed ?
-                        (<Icon name='chevron down' onClick={() => { setProfCollapsed(false) }} />) :
-                        (<Icon name='chevron up' onClick={() => setProfCollapsed(true)} />) :
-                    null
-                }
                 <ul>
                     {(!profCollapsed && course.professors.length > profDefaultSize)
                         && course.professors.slice(profDefaultSize, course.professors.length).map(id => {
@@ -95,20 +85,21 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
                             );
                         })}
                 </ul>
+
+                <br />
+
+                {/* Display icon only if the number of professors is greater than the default size */}
+                {course.professors.length > profDefaultSize ?
+                    profCollapsed ?
+                        (<Icon name='chevron down' onClick={() => { setProfCollapsed(false) }} />) :
+                        (<Icon name='chevron up' onClick={() => setProfCollapsed(true)} />) :
+                    null
+                }
             </div>
             <div className="course-section">
                 <h3>TAs</h3>
                 {course.tas.length === 0 && <div>None</div>}
                 {displayRoleList(course.tas, "t", taDefaultSize)}
-
-                <br />
-                {/* Display icon only if the number of TAs is greater than the default size */}
-                {course.tas.length > taDefaultSize ?
-                    taCollapsed ?
-                        (<Icon name='chevron down' onClick={() => { setTaCollapsed(false) }} />) :
-                        (<Icon name='chevron up' onClick={() => setTaCollapsed(true)} />) :
-                    null
-                }
                 <ul>
                     {(!taCollapsed && course.tas.length > taDefaultSize)
                         && course.tas.slice(taDefaultSize, course.tas.length).map(id => {
@@ -123,6 +114,16 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
                             );
                         })}
                 </ul>
+
+                <br />
+
+                {/* Display icon only if the number of TAs is greater than the default size */}
+                {course.tas.length > taDefaultSize ?
+                    taCollapsed ?
+                        (<Icon name='chevron down' onClick={() => { setTaCollapsed(false) }} />) :
+                        (<Icon name='chevron up' onClick={() => setTaCollapsed(true)} />) :
+                    null
+                }
             </div>
         </div>
     );

--- a/src/components/includes/AdminReadOnlyCourseCard.tsx
+++ b/src/components/includes/AdminReadOnlyCourseCard.tsx
@@ -10,6 +10,42 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
     const [profCollapsed, setProfCollapsed] = useState(true);
     const [taCollapsed, setTaCollapsed] = useState(true);
 
+    const makeRoleList = (listType: string, collapsed: boolean) => {
+        if (listType === "p") {
+            return (
+                <ul>
+                    {(collapsed || course.professors.length <= 2) && course.professors.map(id => {
+                        const professor = professorMap[id];
+                        if (professor === null || professor === undefined) {
+                            return null;
+                        }
+                        return (
+                            <li key={id}>
+                                {professor.firstName}  {professor.lastName} ({professor.email})
+                            </li>
+                        );
+                    })}
+                </ul>
+            )
+        }
+        return (
+            <ul>
+                {!collapsed && course.tas.map(id => {
+                    const ta = taMap[id];
+                    if (ta === null || ta === undefined) {
+                        return null;
+                    }
+                    return (
+                        <li key={id}>
+                            {ta.firstName} {ta.lastName} ({ta.email})
+                        </li>
+                    );
+                })}
+            </ul>
+        )
+
+    }
+
     return (
         <div>
             <div className="course-section">
@@ -25,15 +61,18 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
             </div>
             <div className="course-section">
                 <h3>Professors</h3>
-                {/* if there are any professors in the list, the collapsible option is displayed */}
-                {course.professors.length === 0 ? true :
-                    profCollapsed ? (<Icon name='chevron down' onClick={() => { setProfCollapsed(false) }} />) :
-                        (<Icon name='chevron up' onClick={() => setProfCollapsed(true)} />)}
+                {/* if there are more than 2 professors in the list, the collapsible option is displayed */}
+                {
+                    course.professors.length > 2 ?
+                        profCollapsed ?
+                            (<Icon name='chevron down' onClick={() => { setProfCollapsed(false) }} />) :
+                            (<Icon name='chevron up' onClick={() => setProfCollapsed(true)} />) :
+                        null}
 
                 {course.professors.length === 0 && <div>None</div>}
 
-                <ul>
-                    {!profCollapsed && course.professors.map(id => {
+                {/* <ul>
+                    {(!profCollapsed || course.professors.length <= 2) && course.professors.map(id => {
                         const professor = professorMap[id];
                         if (professor === null || professor === undefined) {
                             return null;
@@ -44,7 +83,8 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
                             </li>
                         );
                     })}
-                </ul>
+                </ul> */}
+                {makeRoleList("p", profCollapsed)}
             </div>
             <div className="course-section">
                 <h3>TAs</h3>
@@ -54,7 +94,7 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
                         (<Icon name='chevron up' onClick={() => setTaCollapsed(true)} />)}
 
                 {course.tas.length === 0 && <div>None</div>}
-                <ul>
+                {/* <ul>
                     {!taCollapsed && course.tas.map(id => {
                         const ta = taMap[id];
                         if (ta === null || ta === undefined) {
@@ -66,7 +106,8 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
                             </li>
                         );
                     })}
-                </ul>
+                </ul> */}
+                {makeRoleList("t", taCollapsed)}
             </div>
         </div>
     );

--- a/src/components/includes/AdminReadOnlyCourseCard.tsx
+++ b/src/components/includes/AdminReadOnlyCourseCard.tsx
@@ -2,10 +2,13 @@ import React, { useState } from 'react';
 import { useCourseProfessorMap, useCourseTAMap } from '../../firehooks';
 import { Icon } from 'semantic-ui-react';
 
+
+
 const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) => {
     const professorMap = useCourseProfessorMap(course);
     const taMap = useCourseTAMap(course);
-    const [collapsed, setCollapsed] = useState(true);
+    const [profCollapsed, setProfCollapsed] = useState(true);
+    const [taCollapsed, setTaCollapsed] = useState(true);
 
     return (
         <div>
@@ -22,16 +25,16 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
             </div>
             <div className="course-section">
                 <h3>Professors</h3>
+                {course.professors.length === 0 ? true :
+                    profCollapsed ? (<Icon name='chevron down' onClick={() => { setProfCollapsed(false) }} />) :
+                        (<Icon name='chevron up' onClick={() => setProfCollapsed(true)} />)}
 
-                {collapsed ? (<Icon name='chevron down' onClick={() => { setCollapsed(false) }} />) :
-                    (<Icon name='chevron up' onClick={() => setCollapsed(true)} />)}
+
 
                 {course.professors.length === 0 && <div>None</div>}
 
-                { /* gotta modify somewhere here*/}
-
                 <ul>
-                    {course.professors.map(id => {
+                    {!profCollapsed && course.professors.map(id => {
                         const professor = professorMap[id];
                         if (professor === null || professor === undefined) {
                             return null;
@@ -46,9 +49,13 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
             </div>
             <div className="course-section">
                 <h3>TAs</h3>
+                {course.tas.length === 0 ? true :
+                    taCollapsed ? (<Icon name='chevron down' onClick={() => { setTaCollapsed(false) }} />) :
+                        (<Icon name='chevron up' onClick={() => setTaCollapsed(true)} />)}
+
                 {course.tas.length === 0 && <div>None</div>}
                 <ul>
-                    {course.tas.map(id => {
+                    {!taCollapsed && course.tas.map(id => {
                         const ta = taMap[id];
                         if (ta === null || ta === undefined) {
                             return null;

--- a/src/components/includes/AdminReadOnlyCourseCard.tsx
+++ b/src/components/includes/AdminReadOnlyCourseCard.tsx
@@ -9,57 +9,45 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
     const taMap = useCourseTAMap(course);
     const [profCollapsed, setProfCollapsed] = useState(true);
     const [taCollapsed, setTaCollapsed] = useState(true);
+    const profDefaultSize = 2;
+    const taDefaultSize = 4;
 
-    const displayRoleList = (listType: string, collapsed: boolean, defaultSize: number) => {
-        if (listType === "p") {
+    const displayRoleList = (list: readonly string[], roleType: string, defaultSize: number) => {
+
+        if (list.length <= defaultSize) {
             return (
                 <ul>
-                    {/* If prof list is less than or equal to default size display everything otherwise display up to the default size */}
-                    {(course.professors.length <= defaultSize) ? course.professors.map(id => {
-                        const professor = professorMap[id];
-                        if (professor === null || professor === undefined) {
+                    {list.map(id => {
+                        const role = roleType === "p" ? professorMap[id] : taMap[id];
+
+                        if (role === null || role === undefined) {
                             return null;
                         }
 
                         return (
                             <li key={id}>
-                                {professor.firstName}  {professor.lastName} ({professor.email})
+                                {role.firstName}  {role.lastName} ({role.email})
                             </li>
                         );
-                    })
-                        :
-                        course.professors.slice(0, defaultSize).map(id => {
-                            const professor = professorMap[id];
-                            if (professor === null || professor === undefined) {
-                                return null;
-                            }
-
-                            return (
-                                <li key={id}>
-                                    {professor.firstName}  {professor.lastName} ({professor.email})
-                                </li>
-                            );
-                        })}
-
+                    })}
                 </ul>
             )
         }
         return (
             <ul>
-                {!collapsed && course.tas.map(id => {
-                    const ta = taMap[id];
-                    if (ta === null || ta === undefined) {
+                {list.slice(0, defaultSize).map(id => {
+                    const role = roleType === "p" ? professorMap[id] : taMap[id];
+                    if (role === null || role === undefined) {
                         return null;
                     }
                     return (
                         <li key={id}>
-                            {ta.firstName} {ta.lastName} ({ta.email})
+                            {role.firstName}  {role.lastName} ({role.email})
                         </li>
                     );
                 })}
             </ul>
         )
-
     }
 
     return (
@@ -77,43 +65,20 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
             </div>
             <div className="course-section">
                 <h3>Professors</h3>
-                {/* if there are more than 2 professors in the list, the collapsible option is displayed */}
-                {/* {
-                    course.professors.length > 2 ?
-                        profCollapsed ?
-                            (<Icon name='chevron down' onClick={() => { setProfCollapsed(false) }} />) :
-                            (<Icon name='chevron up' onClick={() => setProfCollapsed(true)} />) :
-                        null} */}
-
                 {course.professors.length === 0 && <div>None</div>}
-
-                {/* <ul>
-                    {(!profCollapsed || course.professors.length <= 2) && course.professors.map(id => {
-                        const professor = professorMap[id];
-                        if (professor === null || professor === undefined) {
-                            return null;
-                        }
-                        return (
-                            <li key={id}>
-                                {professor.firstName}  {professor.lastName} ({professor.email})
-                            </li>
-                        );
-                    })}
-                </ul> */}
-                {displayRoleList("p", profCollapsed, 2)}
+                {displayRoleList(course.professors, "p", profDefaultSize)}
 
                 <br />
 
-                {
-                    course.professors.length > 2 ?
-                        profCollapsed ?
-                            (<Icon name='chevron down' onClick={() => { setProfCollapsed(false) }} />) :
-                            (<Icon name='chevron up' onClick={() => setProfCollapsed(true)} />) :
-                        null
+                {course.professors.length > profDefaultSize ?
+                    profCollapsed ?
+                        (<Icon name='chevron down' onClick={() => { setProfCollapsed(false) }} />) :
+                        (<Icon name='chevron up' onClick={() => setProfCollapsed(true)} />) :
+                    null
                 }
                 <ul>
-                    {(!profCollapsed && course.professors.length > 2)
-                        && course.professors.slice(2, course.professors.length).map(id => {
+                    {(!profCollapsed && course.professors.length > profDefaultSize)
+                        && course.professors.slice(profDefaultSize, course.professors.length).map(id => {
                             const professor = professorMap[id];
                             if (professor === null || professor === undefined) {
                                 return null;
@@ -125,31 +90,34 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
                             );
                         })}
                 </ul>
-
-
             </div>
             <div className="course-section">
                 <h3>TAs</h3>
-                {/* if there are any TAs in the list, the collapsible option is displayed */}
-                {course.tas.length === 0 ? true :
-                    taCollapsed ? (<Icon name='chevron down' onClick={() => { setTaCollapsed(false) }} />) :
-                        (<Icon name='chevron up' onClick={() => setTaCollapsed(true)} />)}
-
                 {course.tas.length === 0 && <div>None</div>}
-                {/* <ul>
-                    {!taCollapsed && course.tas.map(id => {
-                        const ta = taMap[id];
-                        if (ta === null || ta === undefined) {
-                            return null;
-                        }
-                        return (
-                            <li key={id}>
-                                {ta.firstName} {ta.lastName} ({ta.email})
-                            </li>
-                        );
-                    })}
-                </ul> */}
-                {displayRoleList("t", taCollapsed, 4)}
+                {displayRoleList(course.tas, "t", taDefaultSize)}
+
+                <br />
+
+                {course.tas.length > taDefaultSize ?
+                    taCollapsed ?
+                        (<Icon name='chevron down' onClick={() => { setTaCollapsed(false) }} />) :
+                        (<Icon name='chevron up' onClick={() => setTaCollapsed(true)} />) :
+                    null
+                }
+                <ul>
+                    {(!taCollapsed && course.tas.length > taDefaultSize)
+                        && course.tas.slice(taDefaultSize, course.tas.length).map(id => {
+                            const ta = taMap[id];
+                            if (ta === null || ta === undefined) {
+                                return null;
+                            }
+                            return (
+                                <li key={id}>
+                                    {ta.firstName}  {ta.lastName} ({ta.email})
+                                </li>
+                            );
+                        })}
+                </ul>
             </div>
         </div>
     );

--- a/src/components/includes/AdminReadOnlyCourseCard.tsx
+++ b/src/components/includes/AdminReadOnlyCourseCard.tsx
@@ -21,26 +21,23 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
     */
     const displayRoleList = (list: readonly string[], roleType: string, defaultSize: number) => {
 
-        if (list.length <= defaultSize) {
-            return (
-                <ul>
-                    {list.map(id => {
-                        const role = roleType === "p" ? professorMap[id] : taMap[id];
+        return (list.length <= defaultSize) ? (
+            <ul>
+                {list.map(id => {
+                    const role = roleType === "p" ? professorMap[id] : taMap[id];
 
-                        if (role === null || role === undefined) {
-                            return null;
-                        }
+                    if (role === null || role === undefined) {
+                        return null;
+                    }
 
-                        return (
-                            <li key={id}>
-                                {role.firstName}  {role.lastName} ({role.email})
-                            </li>
-                        );
-                    })}
-                </ul>
-            )
-        }
-        return (
+                    return (
+                        <li key={id}>
+                            {role.firstName}  {role.lastName} ({role.email})
+                        </li>
+                    );
+                })}
+            </ul>
+        ) : (
             <ul>
                 {list.slice(0, defaultSize).map(id => {
                     const role = roleType === "p" ? professorMap[id] : taMap[id];

--- a/src/components/includes/AdminReadOnlyCourseCard.tsx
+++ b/src/components/includes/AdminReadOnlyCourseCard.tsx
@@ -10,21 +10,37 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
     const [profCollapsed, setProfCollapsed] = useState(true);
     const [taCollapsed, setTaCollapsed] = useState(true);
 
-    const makeRoleList = (listType: string, collapsed: boolean) => {
+    const displayRoleList = (listType: string, collapsed: boolean, defaultSize: number) => {
         if (listType === "p") {
             return (
                 <ul>
-                    {(collapsed || course.professors.length <= 2) && course.professors.map(id => {
+                    {/* If prof list is less than or equal to default size display everything otherwise display up to the default size */}
+                    {(course.professors.length <= defaultSize) ? course.professors.map(id => {
                         const professor = professorMap[id];
                         if (professor === null || professor === undefined) {
                             return null;
                         }
+
                         return (
                             <li key={id}>
                                 {professor.firstName}  {professor.lastName} ({professor.email})
                             </li>
                         );
-                    })}
+                    })
+                        :
+                        course.professors.slice(0, defaultSize).map(id => {
+                            const professor = professorMap[id];
+                            if (professor === null || professor === undefined) {
+                                return null;
+                            }
+
+                            return (
+                                <li key={id}>
+                                    {professor.firstName}  {professor.lastName} ({professor.email})
+                                </li>
+                            );
+                        })}
+
                 </ul>
             )
         }
@@ -62,12 +78,12 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
             <div className="course-section">
                 <h3>Professors</h3>
                 {/* if there are more than 2 professors in the list, the collapsible option is displayed */}
-                {
+                {/* {
                     course.professors.length > 2 ?
                         profCollapsed ?
                             (<Icon name='chevron down' onClick={() => { setProfCollapsed(false) }} />) :
                             (<Icon name='chevron up' onClick={() => setProfCollapsed(true)} />) :
-                        null}
+                        null} */}
 
                 {course.professors.length === 0 && <div>None</div>}
 
@@ -84,7 +100,33 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
                         );
                     })}
                 </ul> */}
-                {makeRoleList("p", profCollapsed)}
+                {displayRoleList("p", profCollapsed, 2)}
+
+                <br />
+
+                {
+                    course.professors.length > 2 ?
+                        profCollapsed ?
+                            (<Icon name='chevron down' onClick={() => { setProfCollapsed(false) }} />) :
+                            (<Icon name='chevron up' onClick={() => setProfCollapsed(true)} />) :
+                        null
+                }
+                <ul>
+                    {(!profCollapsed && course.professors.length > 2)
+                        && course.professors.slice(2, course.professors.length).map(id => {
+                            const professor = professorMap[id];
+                            if (professor === null || professor === undefined) {
+                                return null;
+                            }
+                            return (
+                                <li key={id}>
+                                    {professor.firstName}  {professor.lastName} ({professor.email})
+                                </li>
+                            );
+                        })}
+                </ul>
+
+
             </div>
             <div className="course-section">
                 <h3>TAs</h3>
@@ -107,7 +149,7 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
                         );
                     })}
                 </ul> */}
-                {makeRoleList("t", taCollapsed)}
+                {displayRoleList("t", taCollapsed, 4)}
             </div>
         </div>
     );

--- a/src/components/includes/AdminReadOnlyCourseCard.tsx
+++ b/src/components/includes/AdminReadOnlyCourseCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { useCourseProfessorMap, useCourseTAMap } from '../../firehooks';
 import { Icon } from 'semantic-ui-react';
+import { useCourseProfessorMap, useCourseTAMap } from '../../firehooks';
 
 
 
@@ -25,11 +25,10 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
             </div>
             <div className="course-section">
                 <h3>Professors</h3>
+                {/* if there are any professors in the list, the collapsible option is displayed */}
                 {course.professors.length === 0 ? true :
                     profCollapsed ? (<Icon name='chevron down' onClick={() => { setProfCollapsed(false) }} />) :
                         (<Icon name='chevron up' onClick={() => setProfCollapsed(true)} />)}
-
-
 
                 {course.professors.length === 0 && <div>None</div>}
 
@@ -49,6 +48,7 @@ const AdminReadOnlyCourseCard = ({ course }: { readonly course: FireCourse }) =>
             </div>
             <div className="course-section">
                 <h3>TAs</h3>
+                {/* if there are any TAs in the list, the collapsible option is displayed */}
                 {course.tas.length === 0 ? true :
                     taCollapsed ? (<Icon name='chevron down' onClick={() => { setTaCollapsed(false) }} />) :
                         (<Icon name='chevron up' onClick={() => setTaCollapsed(true)} />)}

--- a/src/styles/AdminView.scss
+++ b/src/styles/AdminView.scss
@@ -1,5 +1,6 @@
 .AdminView {
     position: relative;
+
     .course-container {
         width: 100%;
         display: flex;
@@ -18,9 +19,10 @@
         border-radius: 4px;
         text-decoration: none;
         cursor: pointer;
+
         &:focus {
             outline: none;
-          }
+        }
     }
 
     .course {
@@ -38,21 +40,34 @@
             background-color: white;
             border: solid 1px #484848;
             border-radius: 4px;
+            font-family: Lato, 'Helvetica Neue', Arial, Helvetica, sans-serif;
             text-decoration: none;
             padding: .5em;
             margin: .25em;
             cursor: pointer;
+            transition: 0.3s;
         }
-    
+
+        .editing-button:hover {
+            background-color: rgb(239, 255, 255);
+        }
+
         .roles-button {
             display: inline-block;
             background-color: white;
             border: solid 1px #484848;
             border-radius: 4px;
+            font-family: Lato, 'Helvetica Neue', Arial, Helvetica, sans-serif;
             text-decoration: none;
             padding: .5em;
             margin: .25em;
             cursor: pointer;
+            transition: 0.3s;
+        }
+
+        .roles-button:hover {
+            background-color: rgb(239, 255, 255);
+
         }
     }
 }

--- a/src/styles/AdminView.scss
+++ b/src/styles/AdminView.scss
@@ -49,7 +49,8 @@
         }
 
         .editing-button:hover {
-            background-color: rgb(239, 255, 255);
+            background-color: #5599DB;
+            color: white;
         }
 
         .roles-button {
@@ -66,7 +67,8 @@
         }
 
         .roles-button:hover {
-            background-color: rgb(239, 255, 255);
+            background-color: #5599DB;
+            color: white;
 
         }
     }


### PR DESCRIPTION
### Summary

- added icons to collapse professor and TA lists

- editing and roles button now change color when the cursor hovers over them

<img width="446" alt="Screen Shot 2024-03-07 at 9 37 53 PM" src="https://github.com/cornell-dti/office-hours/assets/57076607/1eeba15b-4403-4483-9612-42860fec3998">

![image](https://github.com/cornell-dti/office-hours/assets/57076607/f562565d-5def-4f04-823d-5e362739028b)

### Notes

- icons should appear when there is at least one person in the TA/Professor list, otherwise only "None" should be displayed

### Test Plan <!-- Required -->

- Hover mouse over editing and roles button to see if they change
- Check that icons default to being collapsed
- Check that clicking icons toggles between collapsed and expanded list
- Change users to be different roles and see if the icons appear accordingly

### Checklist

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
