### PR TITLE
Bug fix: Enabled deleting OH

### DIFF
--- a/src/components/includes/ProfessorOHInfoDelete.tsx
+++ b/src/components/includes/ProfessorOHInfoDelete.tsx
@@ -79,7 +79,6 @@ const ProfessorOHInfoDelete = ({ course, session, toggleDelete, toggleEdit }: Pr
                     toggleDelete();
                     toggleEdit();
                 }}
-                disabled={disable}
             >
                 Delete
             </button>


### PR DESCRIPTION
### Summary <!-- Required -->

Previously we were not able to delete an OH session/series if it had passed. I removed the logic for checking if an OH has passed so that all OH sessions would be deletable.

<!-- Add your summary here -->

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->

<!-- Briefly describe how you test you changes. -->
Before: 
<img width="1250" alt="image" src="https://github.com/cornell-dti/office-hours/assets/53349391/5c4b7cec-f6e2-4d00-adf8-9013c8871362">
After:
<img width="1255" alt="image" src="https://github.com/cornell-dti/office-hours/assets/53349391/4f2368c3-f773-4aa7-8881-a2711537e5fc">


### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
