### PR TITLE
Loading Screen to Welcome Screen

### DIFF
--- a/src/components/includes/Wrapped.tsx
+++ b/src/components/includes/Wrapped.tsx
@@ -102,6 +102,13 @@ const Wrapped= (props: Props): JSX.Element => {
         </div>
     );
 
+    const handleAnimationEnd = () => {
+        const timer = setTimeout(() => {
+            setLoading(false);
+        }, 1000); 
+        return () => clearTimeout(timer);
+    }
+
     const WrappedAnimationModal = () =>
         (                 
             <div className='qmi-container'>
@@ -156,12 +163,7 @@ const Wrapped= (props: Props): JSX.Element => {
                     src={bigPlus}
                     className="sec-plus"
                     alt="second plus"
-                    onAnimationEnd={() => {
-                        const timer = setTimeout(() => {
-                            setLoading(false);
-                        }, 1000); 
-                        return () => clearTimeout(timer);
-                    }}
+                    onAnimationEnd={handleAnimationEnd}
                 />
                 
             </div>
@@ -169,7 +171,8 @@ const Wrapped= (props: Props): JSX.Element => {
       
 
     const Welcome = () => (
-        loading ? (<> </>) : 
+        <>
+            {!loading && 
             (
                 <div>
                     <div style={{ display: "flex", flexDirection: "column", 
@@ -197,9 +200,8 @@ const Wrapped= (props: Props): JSX.Element => {
                     </div>
                 </div>
             )
-    
-    
-    
+            }
+        </>
     );
 
     const Visits = () => (

--- a/src/components/includes/Wrapped.tsx
+++ b/src/components/includes/Wrapped.tsx
@@ -5,6 +5,7 @@ import CloseIcon from '@material-ui/icons/Close';
 import ArrowForwardIosIcon from '@material-ui/icons/ArrowForwardIos';
 import ArrowBackIosIcon from '@material-ui/icons/ArrowBackIos';
 import "../../styles/Wrapped.scss";
+import "../../styles/WrappedAnimation.scss";
 import React, { useEffect, useState } from "react";
 import firebase from '../../firebase';
 import Couple from "../../media/wrapped/couple.svg"
@@ -13,6 +14,9 @@ import Bus from "../../media/wrapped/bus.svg"
 import ConsistentPersonality from "../../media/wrapped/consistent_personality.svg"
 import ResourcefulPersonality from "../../media/wrapped/resourceful_personality.svg"
 import IndependentPersonality from "../../media/wrapped/independent_personality.svg"
+import arrow from '../../media/wrapped/arrow.svg';
+import smallPlus from '../../media/wrapped/plus.svg';
+import bigPlus from '../../media/wrapped/plus2.svg';
 
 type Props = {
     user: FireUser | undefined;
@@ -22,6 +26,7 @@ type Props = {
 type DotProps = {
     active: boolean;
 };
+
   
 const Dot = ({active} : DotProps) => (
     <div className={`dot ${active ? 'active' : ''}`} />
@@ -62,7 +67,7 @@ const Wrapped = (props: Props) => {
                 // eslint-disable-next-line no-console
                 console.error("Error fetching data: ", error);
             }
-            setLoading(false);
+            // setLoading(false);
         };
 
         fetchData();
@@ -93,32 +98,105 @@ const Wrapped = (props: Props) => {
             ))}
         </div>
     );
+
+    const WrappedAnimationModal = () =>
+        ( 
+            
+        // <div className='WrappedModalScreen'>
+        //     <div className={'WrappedModal' + isShown}>
+        /* <button type='button' className='closeButton' onClick={closeModal}>
+                                <Icon name='x' />
+                            </button> */
+                            
+            <div className='qmi-container'>
+                                
+                {/* creates first red svg circle. need linear gradient tags here 
+              since didn't import this svg.
+              make note that width and height are basically the box containing the circle,
+              so they need to be double the radius
+              */}
+                <svg className="red-circle" width="300" height="300">
+                    {/* this creates the color gradients on the qmi logo */}
+                    <defs>
+                        <linearGradient 
+                            id="red-gradient" 
+                            x1="24.4251" 
+                            y1="-52.6352" 
+                            x2="112.279" 
+                            y2="143.659" 
+                            gradientUnits="userSpaceOnUse"
+                        >
+                            <stop stopColor="#FF9399" />
+                            <stop offset="1" stopColor="#FF5A60" />
+                        </linearGradient>
+                    </defs>
+                                    
+                    {/* this is the actual circle part. 
+                                    cx and cy are centers so shld be half of height/width. r is radius */}
+                    <circle cx='150' cy='150' r='115'> </circle>
+                </svg>
+                <svg className="blue-circle" width="400" height="400">
+                    <defs>
+                        <linearGradient 
+                            id="blue-gradient" 
+                            x1="36.7649" 
+                            y1="66.8832" 
+                            x2="134.326" 
+                            y2="192.278" 
+                            gradientUnits="userSpaceOnUse"
+                        >
+                            <stop stopColor="#B2D9FF" />
+                            <stop offset="1" stopColor="#78B6F4" />
+                        </linearGradient>
+                    </defs>
+                    <circle cx='200' cy='200' r='180'> </circle>
+                </svg>
+                {/* imported way of using svgs, so cant adjust stroke colors */}
+                <img src={arrow} className="arrow-circle" alt="dti arrow" />
+                {/* made two pluses since color gradient changes and second one needs
+               to expand outside of the container. */}
+                <img src={smallPlus} className="first-plus" alt="first plus" />
+                <img src={bigPlus} className="sec-plus" alt="second plus" onAnimationEnd={() => setLoading(false)} />
+                
+            </div>
+            
+
+            
+        //     </div>
+        // </div>
+        )
       
 
     const Welcome = () => (
-        <div>
-            <div style={{ display: "flex", flexDirection: "column", width: "400px", justifyContent: "space-between" }}>
-                <div style={{ alignSelf: "flex-start" }}>
-                    <Typography variant="h2" style={{ fontWeight: "bold" }}> Queue Me In</Typography>
-                </div>
-                <div style={{ alignSelf: "flex-end" }}>
-                    <Typography variant="h1" style={{ fontWeight: "bold" }}> Wrapped</Typography>
-                </div>
-                <div className="animationContainer">
-                    {showBanner && (
-                        <>
-                            <div className="banner top-right">
+        loading ? (<> </>) : 
+            (
+                <div>
+                    <div style={{ display: "flex", flexDirection: "column", width: "400px", justifyContent: "space-between" }}>
+                        <div style={{ alignSelf: "flex-start" }} className="intro-title">
+                            <Typography variant="h2" style={{ fontWeight: "bold" }}> Queue Me In</Typography>
+                        </div>
+                        <div style={{ alignSelf: "flex-end" }} className="intro-title">
+                            <Typography variant="h1" style={{ fontWeight: "bold" }}> Wrapped</Typography>
+                        </div>
+                        <div className="animationContainer">
+                            {showBanner && (
+                                <>
+                                    <div className="banner top-right">
                                 SPRING 2024 SPRING 2024 SPRING 2024
-                            </div>
-                            <div className="banner bottom-left">
+                                    </div>
+                                    <div className="banner bottom-left">
                                 SPRING 2024 SPRING 2024 SPRING 2024
-                            </div>
-                        </>
-                    )}
+                                    </div>
+                                </>
+                            )}
+                        </div>
+                    </div>
                 </div>
-            </div>
-        </div>
-    )
+            )
+    
+    
+    
+    );
 
     const Visits = () => (
         <div>
@@ -333,7 +411,7 @@ const Wrapped = (props: Props) => {
     return (
         <div className="wrappedBackground">
             <div className="wrappedContainer">
-                {loading && <div>Loading...</div>}
+                {loading && <WrappedAnimationModal />}
                 {stage !== 0 && 
                     <div className="navigateStage prev" onClick={() => navigateStage('prev')}> 
                         <ArrowBackIosIcon />

--- a/src/components/includes/Wrapped.tsx
+++ b/src/components/includes/Wrapped.tsx
@@ -27,12 +27,16 @@ type DotProps = {
     active: boolean;
 };
 
+type DotIndicatorProps = {
+    showDots: string
+}
+
   
 const Dot = ({active} : DotProps) => (
     <div className={`dot ${active ? 'active' : ''}`} />
 );
 
-const Wrapped = (props: Props) => {
+const Wrapped= (props: Props): JSX.Element => {
     const [loading, setLoading] = useState<boolean>(true);
     const [stage, setStage] = useState<number>(0);
     const [wrappedData, setWrappedData] = useState({
@@ -47,7 +51,6 @@ const Wrapped = (props: Props) => {
     useEffect(() => {
 
         const wrappedRef = firebase.firestore().collection('wrapped');
-        // eslint-disable-next-line no-console
         const fetchData = async () => {
             setLoading(true);
             try {
@@ -67,7 +70,6 @@ const Wrapped = (props: Props) => {
                 // eslint-disable-next-line no-console
                 console.error("Error fetching data: ", error);
             }
-            // setLoading(false);
         };
 
         fetchData();
@@ -91,8 +93,9 @@ const Wrapped = (props: Props) => {
         });
     };
 
-    const DotsIndicator = () => (
-        <div className="dotsContainer">
+    const DotsIndicator = ({showDots} : DotIndicatorProps) => (
+        
+        <div className={"dotsContainer" + showDots}>
             {[...Array(totalStages)].map((_, index) => ( 
                 <Dot active={index === stage} />
             ))}
@@ -100,14 +103,7 @@ const Wrapped = (props: Props) => {
     );
 
     const WrappedAnimationModal = () =>
-        ( 
-            
-        // <div className='WrappedModalScreen'>
-        //     <div className={'WrappedModal' + isShown}>
-        /* <button type='button' className='closeButton' onClick={closeModal}>
-                                <Icon name='x' />
-                            </button> */
-                            
+        (                 
             <div className='qmi-container'>
                                 
                 {/* creates first red svg circle. need linear gradient tags here 
@@ -156,14 +152,19 @@ const Wrapped = (props: Props) => {
                 {/* made two pluses since color gradient changes and second one needs
                to expand outside of the container. */}
                 <img src={smallPlus} className="first-plus" alt="first plus" />
-                <img src={bigPlus} className="sec-plus" alt="second plus" onAnimationEnd={() => setLoading(false)} />
+                <img
+                    src={bigPlus}
+                    className="sec-plus"
+                    alt="second plus"
+                    onAnimationEnd={() => {
+                        const timer = setTimeout(() => {
+                            setLoading(false);
+                        }, 1000); 
+                        return () => clearTimeout(timer);
+                    }}
+                />
                 
             </div>
-            
-
-            
-        //     </div>
-        // </div>
         )
       
 
@@ -171,7 +172,10 @@ const Wrapped = (props: Props) => {
         loading ? (<> </>) : 
             (
                 <div>
-                    <div style={{ display: "flex", flexDirection: "column", width: "400px", justifyContent: "space-between" }}>
+                    <div style={{ display: "flex", flexDirection: "column", 
+                        width: "400px", justifyContent: "space-between" 
+                    }}
+                    >
                         <div style={{ alignSelf: "flex-start" }} className="intro-title">
                             <Typography variant="h2" style={{ fontWeight: "bold" }}> Queue Me In</Typography>
                         </div>
@@ -413,7 +417,10 @@ const Wrapped = (props: Props) => {
             <div className="wrappedContainer">
                 {loading && <WrappedAnimationModal />}
                 {stage !== 0 && 
-                    <div className="navigateStage prev" onClick={() => navigateStage('prev')}> 
+                    <div 
+                        className={`navigateStage${loading ? '':'Visible prev'}`} 
+                        onClick={() => navigateStage('prev')}
+                    > 
                         <ArrowBackIosIcon />
                     </div>
                 }
@@ -423,9 +430,12 @@ const Wrapped = (props: Props) => {
                 {stage === 2 && <TimeSpent />}
                 {stage === 3 && <PersonalityType />}
                 {stage === 4 && <Conclusion />}
-                <DotsIndicator />
+                <DotsIndicator showDots={loading ? "" : "Visible"} />
                 {stage !== totalStages - 1 && 
-                    <div className="navigateStage next" onClick={() => navigateStage('next')}>
+                    <div 
+                        className={`navigateStage${loading ? '':'Visible next'}`} 
+                        onClick={() => navigateStage('next')}
+                    >
                         <ArrowForwardIosIcon />
                     </div>
                 }
@@ -439,6 +449,5 @@ const Wrapped = (props: Props) => {
         </div>
     );
 };
-
 
 export default Wrapped;

--- a/src/media/wrapped/arrow.svg
+++ b/src/media/wrapped/arrow.svg
@@ -1,0 +1,11 @@
+<svg width="98" height="106" viewBox="0 0 98 106" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="47.9414" width="15" height="68" rx="7.5" transform="rotate(44.831 47.9414 0)" fill="white"/>
+<rect x="47.9414" width="15" height="68" rx="7.5" transform="rotate(44.831 47.9414 0)" fill="white"/>
+<rect x="47.9414" width="15" height="68" rx="7.5" transform="rotate(44.831 47.9414 0)" fill="#4A4A4A"/>
+<rect x="97.3477" y="47.2202" width="15" height="68" rx="7.5" transform="rotate(133.981 97.3477 47.2202)" fill="#4A4A4A"/>
+<rect x="97.3477" y="47.2202" width="15" height="68" rx="7.5" transform="rotate(133.981 97.3477 47.2202)" fill="#4A4A4A"/>
+<rect x="97.3477" y="47.2202" width="15" height="68" rx="7.5" transform="rotate(133.981 97.3477 47.2202)" fill="#4A4A4A"/>
+<rect x="56.3262" y="104.999" width="15" height="68" rx="7.5" transform="rotate(179.725 56.3262 104.999)" fill="#4A4A4A"/>
+<rect x="56.3262" y="104.999" width="15" height="68" rx="7.5" transform="rotate(179.725 56.3262 104.999)" fill="#4A4A4A"/>
+<rect x="56.3262" y="104.999" width="15" height="68" rx="7.5" transform="rotate(179.725 56.3262 104.999)" fill="#4A4A4A"/>
+</svg>

--- a/src/media/wrapped/plus.svg
+++ b/src/media/wrapped/plus.svg
@@ -1,0 +1,9 @@
+<svg width="61" height="61" viewBox="0 0 61 61" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path id="plus" fill-rule="evenodd" clip-rule="evenodd" d="M30.5 0C34.4227 0 37.6027 3.18 37.6027 7.10274L37.6023 23.3965L53.8973 23.3973C57.82 23.3973 61 26.5773 61 30.5C61 34.4227 57.82 37.6027 53.8973 37.6027L37.6023 37.6023L37.6027 53.8973C37.6027 57.82 34.4227 61 30.5 61C26.5773 61 23.3973 57.82 23.3973 53.8973L23.3965 37.6023L7.10274 37.6027C3.18 37.6027 0 34.4227 0 30.5C0 26.5773 3.18 23.3973 7.10274 23.3973L23.3965 23.3965L23.3973 7.10274C23.3973 3.18 26.5773 0 30.5 0Z" fill="url(#paint0_linear_4795_1479)"/>
+<defs>
+<linearGradient id="paint0_linear_4795_1479" x1="42.1342" y1="7.41003" x2="3.31648" y2="41.0668" gradientUnits="userSpaceOnUse">
+<stop stop-color="#B2D9FF"/>
+<stop offset="1" stop-color="#78B6F4"/>
+</linearGradient>
+</defs>
+</svg>

--- a/src/media/wrapped/plus2.svg
+++ b/src/media/wrapped/plus2.svg
@@ -1,7 +1,7 @@
 <svg width="190" height="190" viewBox="0 0 190 190" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path id="Combined Shape" fill-rule="evenodd" clip-rule="evenodd" d="M95 0C107.218 0 117.123 9.90493 117.123 22.1233L117.122 72.8743L167.877 72.8767C180.095 72.8767 190 82.7816 190 95C190 107.218 180.095 117.123 167.877 117.123L117.122 117.122L117.123 167.877C117.123 180.095 107.218 190 95 190C82.7816 190 72.8767 180.095 72.8767 167.877L72.8743 117.122L22.1233 117.123C9.90493 117.123 0 107.218 0 95C0 82.7816 9.90493 72.8767 22.1233 72.8767L72.8743 72.8743L72.8767 22.1233C72.8767 9.90493 82.7816 0 95 0Z" fill="url(#paint0_linear_4795_1485)"/>
 <defs>
-<linearGradient id="paint0_linear_4795_1485" x1="131.238" y1="23.0804" x2="10.33" y2="127.913" gradientUnits="userSpaceOnUse">
+<linearGradient id="paint0_linear_4795_1485" x1="10.33" y1="23.0804" x2="131.238" y2="127.913" gradientUnits="userSpaceOnUse">
 <stop stop-color="#81AFDE"/>
 <stop offset="1" stop-color="#92A7E4"/>
 </linearGradient>

--- a/src/media/wrapped/plus2.svg
+++ b/src/media/wrapped/plus2.svg
@@ -1,0 +1,9 @@
+<svg width="190" height="190" viewBox="0 0 190 190" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path id="Combined Shape" fill-rule="evenodd" clip-rule="evenodd" d="M95 0C107.218 0 117.123 9.90493 117.123 22.1233L117.122 72.8743L167.877 72.8767C180.095 72.8767 190 82.7816 190 95C190 107.218 180.095 117.123 167.877 117.123L117.122 117.122L117.123 167.877C117.123 180.095 107.218 190 95 190C82.7816 190 72.8767 180.095 72.8767 167.877L72.8743 117.122L22.1233 117.123C9.90493 117.123 0 107.218 0 95C0 82.7816 9.90493 72.8767 22.1233 72.8767L72.8743 72.8743L72.8767 22.1233C72.8767 9.90493 82.7816 0 95 0Z" fill="url(#paint0_linear_4795_1485)"/>
+<defs>
+<linearGradient id="paint0_linear_4795_1485" x1="131.238" y1="23.0804" x2="10.33" y2="127.913" gradientUnits="userSpaceOnUse">
+<stop stop-color="#81AFDE"/>
+<stop offset="1" stop-color="#92A7E4"/>
+</linearGradient>
+</defs>
+</svg>

--- a/src/styles/Wrapped.scss
+++ b/src/styles/Wrapped.scss
@@ -27,9 +27,11 @@
   width: 825px;
   height: 475px;
   color: #FFFFFF;
-  background: #80B0DE;
+  background: linear-gradient(90deg, #80B0DE 3.12%, #93A7E4 97.75%);
   align-items: center;
   justify-content: center;
+  box-shadow: 0px 4px 4px 0px #00000040;
+
 
 }
 
@@ -41,7 +43,7 @@
   right: "1.8rem";
 }
 
-.navigateStage {
+.navigateStageVisible {
   position: absolute;
   top: 50%; 
   transform: translateY(-50%);
@@ -73,7 +75,11 @@
   padding-right: 10px;
 }
 
-.dotsContainer {
+.dotsContainer, .navigateStage {
+  display: none;
+}
+
+.dotsContainerVisible {
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/styles/Wrapped.scss
+++ b/src/styles/Wrapped.scss
@@ -52,6 +52,7 @@
   align-items: center;
   justify-content: center;
   background-color: rgba(255, 255, 255, 0);
+  transition: 0.5s;
   &:hover {
       background-color: rgba(255, 255, 255, 0.1);
   }
@@ -116,6 +117,25 @@
       left: 0;
       opacity: 1;
   }
+}
+
+@keyframes fadeIn {
+  0% {
+    opacity: 0%
+  }
+
+  100% {
+    opacity: 100%;
+  }
+}
+
+.intro-title{
+  animation: fadeIn 1s ease-in both;
+}
+
+.intro-title:nth-child(2) {
+  animation-delay: 0.75s;
+  animation-duration: 0.5s;
 }
 
 .banner {

--- a/src/styles/WrappedAnimation.scss
+++ b/src/styles/WrappedAnimation.scss
@@ -1,58 +1,27 @@
-.WrappedModalVisible {
-  text-align: center;
-  background-color: whitesmoke;
-  height: 70vh;
-  width: 60vw;
-  overflow: hidden;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  border-radius: 8px;
-
-  .closeButton {
-    z-index: 5;
-    align-self: flex-end;
-    height: 45px;
-    left: 74.14%;
-    right: 24.61%;
-    top: calc(50% - 45px / 2 - 209.5px);
-    font-size: 20px;
-    color: #484848;
-    float: right;
-    outline: none;
-    background-color: transparent;
-    border: none;
-    padding-top: 8px;
-    padding-right: 8px;
-  }
-
-}
-
 .qmi-container {
   z-index: 0;
-  margin-top: -10px;
+  border-radius: 8px;
   background-color: whitesmoke;
-  position: relative;
+  position: absolute;
   display: flex;
+  padding: 2rem;
   width: 100%;
   height: 100%;
+  top: 0;
+  bottom: 0;
   align-content: center;
   justify-content: center;
+  overflow:clip;
+
 }
 
-/* made positons based on font-size so it should also look good for smaller screens */
-.red-circle {
+.red-circle, .blue-circle{
   position: absolute;
-  // top: 20%;
-  margin-top: 3.5em;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
-.blue-circle {
-  position: absolute;
-  // top: 20%;
-}
 
 /* stroke array is length of path, so circumference. recalculate if radius changes.
 dashoffset is percentage to draw of the path
@@ -66,7 +35,8 @@ dashoffset is percentage to draw of the path
   stroke-width: 17;
   transform: rotate(45deg);
   stroke: #FF5A60;
-  animation: red-spin 2s 0.5s ease-in-out both;
+  animation: red-spin 2s 0.8s ease-in-out both;
+  will-change: transform;
 }
 
 .blue-circle circle {
@@ -78,28 +48,30 @@ dashoffset is percentage to draw of the path
   transform: rotate(45deg);
   stroke: url(#blue-gradient);
   stroke-linecap: round;
-  animation: blue-spin 1.5s 1.5s ease-out both;
+  animation: blue-spin 1.5s 1.5s cubic-bezier(0.215, 0.610, 0.355, 1) both;
 }
 
 .arrow-circle {
   position: absolute;
   transform-origin: 50% 50%;
   transform-box: fill-box;
-  // top: 25%;
-  margin-top: 10em;
-  animation: spin 2.5s 0.5s ease-in-out both,
-    fadeArrow 0.5s 3s ease-in both;
+  top: 40%;
+  animation: spin 2.5s 0.8s ease-in-out both, 
+  fadeArrow 0.5s 3s ease-in both;
+  will-change: transform;
 }
+
 /* Needed two pluses since QMI plus is visibly different gradient than 
 QMI Wrapped background. First plus applied to logo part of animation, 
 second plus is used for the expanding transition into background. */
+
 .first-plus,
 .sec-plus {
   position: absolute;
-  // top: 25%;
-  margin-top: 21em;
+  top: 50%;
   left: 50%;
   margin-left: 7em;
+  margin-top: 7em;
 }
 
 /* controls when the pluses appear/disappear. in sync with each others delays*/
@@ -118,6 +90,9 @@ second plus is used for the expanding transition into background. */
 }
 
 @keyframes spin {
+  0% {
+    transform: rotate(0deg)
+  }
   100% {
     transform: rotate(360deg)
   }
@@ -135,6 +110,7 @@ second plus is used for the expanding transition into background. */
 @keyframes grow {
   100% {
     transform: scale(70);
+    background-color:none;
   }
 }
 

--- a/src/styles/WrappedAnimation.scss
+++ b/src/styles/WrappedAnimation.scss
@@ -12,7 +12,6 @@
   align-content: center;
   justify-content: center;
   overflow:clip;
-
 }
 
 .red-circle, .blue-circle{

--- a/src/styles/WrappedAnimation.scss
+++ b/src/styles/WrappedAnimation.scss
@@ -1,0 +1,204 @@
+.WrappedModalVisible {
+  text-align: center;
+  background-color: whitesmoke;
+  height: 70vh;
+  width: 60vw;
+  overflow: hidden;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+
+  .closeButton {
+    z-index: 5;
+    align-self: flex-end;
+    height: 45px;
+    left: 74.14%;
+    right: 24.61%;
+    top: calc(50% - 45px / 2 - 209.5px);
+    font-size: 20px;
+    color: #484848;
+    float: right;
+    outline: none;
+    background-color: transparent;
+    border: none;
+    padding-top: 8px;
+    padding-right: 8px;
+  }
+
+}
+
+.qmi-container {
+  z-index: 0;
+  margin-top: -10px;
+  background-color: whitesmoke;
+  position: relative;
+  display: flex;
+  width: 100%;
+  height: 100%;
+  align-content: center;
+  justify-content: center;
+}
+
+/* made positons based on font-size so it should also look good for smaller screens */
+.red-circle {
+  position: absolute;
+  // top: 20%;
+  margin-top: 3.5em;
+}
+
+.blue-circle {
+  position: absolute;
+  // top: 20%;
+}
+
+/* stroke array is length of path, so circumference. recalculate if radius changes.
+dashoffset is percentage to draw of the path
+*/
+.red-circle circle {
+  stroke-dashoffset: 60%;
+  stroke-dasharray: 725px;
+  fill: transparent;
+  transform-origin: 50% 50%;
+  transform-box: fill-box;
+  stroke-width: 17;
+  transform: rotate(45deg);
+  stroke: #FF5A60;
+  animation: red-spin 2s 0.5s ease-in-out both;
+}
+
+.blue-circle circle {
+  stroke-dasharray: 1135px;
+  fill: transparent;
+  transform-origin: 50% 50%;
+  transform-box: fill-box;
+  stroke-width: 20;
+  transform: rotate(45deg);
+  stroke: url(#blue-gradient);
+  stroke-linecap: round;
+  animation: blue-spin 1.5s 1.5s ease-out both;
+}
+
+.arrow-circle {
+  position: absolute;
+  transform-origin: 50% 50%;
+  transform-box: fill-box;
+  // top: 25%;
+  margin-top: 10em;
+  animation: spin 2.5s 0.5s ease-in-out both,
+    fadeArrow 0.5s 3s ease-in both;
+}
+/* Needed two pluses since QMI plus is visibly different gradient than 
+QMI Wrapped background. First plus applied to logo part of animation, 
+second plus is used for the expanding transition into background. */
+.first-plus,
+.sec-plus {
+  position: absolute;
+  // top: 25%;
+  margin-top: 21em;
+  left: 50%;
+  margin-left: 7em;
+}
+
+/* controls when the pluses appear/disappear. in sync with each others delays*/
+.first-plus {
+  animation: appear-n-grow 1s 3.5s ease-in-out both,
+    disappear 0.01s 5s linear forwards;
+}
+
+.sec-plus {
+  width: 61px;
+  height: 61px;
+  animation: disappear 5s linear backwards,
+    grow 0.5s 5s ease-in both;
+  overflow: clip;
+
+}
+
+@keyframes spin {
+  100% {
+    transform: rotate(360deg)
+  }
+}
+
+@keyframes disappear {
+
+  0%,
+  100% {
+    opacity: 0%;
+    display: none;
+  }
+}
+
+@keyframes grow {
+  100% {
+    transform: scale(70);
+  }
+}
+
+@keyframes fadeArrow {
+  99% {
+    opacity: 0%
+  }
+
+  100% {
+    opacity: 0%;
+    display: none;
+  }
+}
+
+@keyframes appear-n-grow {
+  0% {
+    opacity: 0%;
+    transform: scale(0.5);
+  }
+
+  80% {
+    opacity: 100%;
+    transform: scale(1.2);
+  }
+
+  100% {
+    opacity: 100%;
+    transform: scale(1);
+  }
+}
+
+@keyframes red-spin {
+  30% {
+    transform: rotate(10deg);
+    stroke-dashoffset: 0%;
+  }
+
+  35% {
+    transform: rotate(10deg);
+    stroke-dashoffset: 0%;
+  }
+
+  40% {
+    stroke-linecap: round;
+  }
+
+  100% {
+    stroke: url(#red-gradient);
+    transform: rotate(90deg);
+    stroke-dashoffset: -70%;
+    stroke-linecap: round;
+    animation-timing-function: ease-out;
+  }
+}
+
+@keyframes blue-spin {
+  0% {
+    stroke-dashoffset: 270%;
+    stroke-opacity: 0%;
+  }
+
+  100% {
+    stroke-opacity: 100%;
+    stroke-dashoffset: 25%;
+    transform: rotate(60deg);
+  }
+}


### PR DESCRIPTION
### Summary 

Building on [this Wrapped Frontend PR](https://github.com/cornell-dti/office-hours/pull/854) and this [animation PR](https://github.com/cornell-dti/office-hours/pull/869), creates a loading animation screen that transitions into the welcome screen.

https://github.com/user-attachments/assets/bf624ea5-5de3-4869-b902-a3ef7349edf4

- Made animation faster
- Fixed some centering issues on different devices

### Test Plan <!-- Required -->

- Loading animation should look centered on different device widths
- No lags or delays, and dots and arrows should only show up after the welcome component is rendered

### Notes

- I made the loading animation have a 0.8s delay because shortening this caused some odd CSS flickering, and this was the lowest time I could go without the flickering

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
