### PR TITLE
Minor Tag Info UI Fixes

### DIFF
--- a/src/components/includes/ProfessorTagInfo.tsx
+++ b/src/components/includes/ProfessorTagInfo.tsx
@@ -200,27 +200,6 @@ class ProfessorTagInfo extends React.Component<PropTypes, State> {
                     </div>
                     <div className="ChildTags InputSection" onKeyDown={(e) => this.handleEnterPress(e)}>
                         <div className="InputHeader">Tags</div>
-                        {this.state.newTags
-                            .map((childTag) => (
-                                <div key={childTag.id} className="SelectedChildTag" >
-                                    <input
-                                        maxLength={30}
-                                        value={childTag.name}
-                                        onChange={
-                                            (event: React.ChangeEvent<HTMLInputElement>): void => {
-                                                this.handleModifyTag(childTag.name, event.currentTarget.value);
-                                            }
-                                        }
-                                        placeholder={'Example: \'Assignment 1\''}
-                                    />
-                                    <Icon
-                                        className="Remove"
-                                        name="close"
-                                        onClick={() => this.handleRemoveChildTag(childTag)}
-                                    />
-                                </div>
-                            ))
-                        }
                         <input
                             className="InputChildTag"
                             maxLength={30}
@@ -233,6 +212,29 @@ class ProfessorTagInfo extends React.Component<PropTypes, State> {
                             onClick={this.handleNewTagEnter}
                         >
                             +
+                        </div>
+                        <div>
+                            {this.state.newTags
+                                .map((childTag) => (
+                                    <div key={childTag.id} className="SelectedChildTag" >
+                                        <input
+                                            maxLength={30}
+                                            value={childTag.name}
+                                            onChange={
+                                                (event: React.ChangeEvent<HTMLInputElement>): void => {
+                                                    this.handleModifyTag(childTag.name, event.currentTarget.value);
+                                                }
+                                            }
+                                            placeholder={'Example: \'Assignment 1\''}
+                                        />
+                                        <Icon
+                                            className="Remove"
+                                            name="close"
+                                            onClick={() => this.handleRemoveChildTag(childTag)}
+                                        />
+                                    </div>
+                                ))
+                            }
                         </div>
                     </div>
                 </div>

--- a/src/styles/professor/ProfessorTagInfo.scss
+++ b/src/styles/professor/ProfessorTagInfo.scss
@@ -60,7 +60,8 @@
             position: relative;
             padding-right: 25px;
             padding-left: 10px;
-
+            margin-bottom: 10px;
+            
             input {
                 background-color: transparent;
             }
@@ -91,6 +92,7 @@
         }
 
         .InputChildTag {
+            margin-bottom: 12px;
             &:focus {
                 outline: none;
             }
@@ -100,7 +102,7 @@
             background: #898989;
             color: #edeff2;
             padding: 1.5px 5px;
-            margin-bottom: 1px;
+            margin-bottom: 12px;
             line-height: 22px;
             vertical-align: bottom;
             width: auto;


### PR DESCRIPTION
### Summary <!-- Required -->

- fixed add new tag input field at the top, under "Tags" and above the persisted list of new tags
- added extra margin so that text field and selected child tags don't get squeezed together

Screenshot of the resulting fixes:
<img width="1142" alt="Screen Shot 2024-11-01 at 12 47 16 PM" src="https://github.com/user-attachments/assets/a2c40dcc-8339-49e2-b3aa-be1e2974dd73">

Previously:
<img width="1143" alt="Screen Shot 2024-11-01 at 12 49 37 PM" src="https://github.com/user-attachments/assets/db5bae8c-7f65-4e60-98fd-5a97919f0b68">


<!-- Provide a general summary of your changes in the Title above -->

<!-- Add your summary here -->

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

