### PR TITLE
Efficient Questions Monitoring

### DIFF
--- a/src/components/includes/SessionView.tsx
+++ b/src/components/includes/SessionView.tsx
@@ -130,14 +130,12 @@ const SessionView = ({
 
             unsubscribe = questionsRef.onSnapshot((snapshot) => {
                 // eslint-disable-next-line no-console
-                console.log("onSnapshot called");
                 snapshot.docChanges().forEach((change) => {
                     const questionData = change.doc.data();
                     const questionId = change.doc.id;
 
                     if (change.type === "modified" && questionData.status === "resolved") {
                         // eslint-disable-next-line no-console
-                        console.log("questionid: ", questionId);
                         removeQuestionDisplayFeedback(questionId);
                     }
                 });


### PR DESCRIPTION
### Summary <!-- Required -->

- only read from the documents in the questions collection that match this session: `firestore.collection("questions").where("sessionId", "==", session.sessionId)`
- remove excess useEffect dependencies so unsubscribe is only called a handful of times, instead of tens of times

Originally, onSnapshot gets called a butt ton of times:

https://github.com/user-attachments/assets/0b00e146-fa06-4b5f-89e5-667cc00231d8


Now, it's only called a handful of times (resizing not shown here, but it doesn't get called on resizing now):

https://github.com/user-attachments/assets/1efc8c61-94ba-4b79-804e-605f32b2bf20


<!-- Provide a general summary of your changes in the Title above -->

<!-- Add your summary here -->

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->

<!-- Briefly describe how you test you changes. -->

Tested that questions feedback form still shows up immediately after a question gets answered and submits properly. Ensured onSnapshot is limited to a few calls instead of racking up tens of queries per question.

### Notes <!-- Optional -->

In the future, this should be registered as a Firebase Cloud Function to initiate an update from the server-side once question status changes, instead of polling for changes from the client-side.

This is a more permanent follow-up fix to [this PR](https://github.com/cornell-dti/office-hours/pull/883), which disables the useEffect entirely (and as a result, collecting student feedback).

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

