### PR TITLE
Fix Lagging intro animation

### DIFF
--- a/src/styles/WrappedAnimation.scss
+++ b/src/styles/WrappedAnimation.scss
@@ -143,16 +143,15 @@ second plus is used for the expanding transition into background. */
 
 @keyframes red-spin {
   30% {
-    transform: rotate(10deg);
     stroke-dashoffset: 0%;
   }
 
   35% {
-    transform: rotate(10deg);
     stroke-dashoffset: 0%;
   }
 
   40% {
+    stroke-dashoffset: 0%;
     stroke-linecap: round;
   }
 


### PR DESCRIPTION
### Summary <!-- Required -->

Fixed unexpected jerks for red circle in loading animation.
Before (on main branch):

https://github.com/user-attachments/assets/64f99330-1f3f-4735-925a-464f359386a9


After: 

https://github.com/user-attachments/assets/7d07fbd6-9f2a-47f4-ab34-379a33407d1b

### Test Plan <!-- Required -->

### Notes <!-- Optional -->
- Unsure why this lag didn't show up on my original branch, but I think removing the extra rotations made the calculations simpler and less laggy
### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
