### PR TITLE
Hide Wrapped Until Clicked

### DIFF
--- a/src/components/includes/CourseSelection.tsx
+++ b/src/components/includes/CourseSelection.tsx
@@ -104,14 +104,6 @@ function CourseSelection({ user, isEdit, allCourses }: Props): React.ReactElemen
         setSelectedCourseIds(selectedCourses.map(course => course.courseId));
     }, [selectedCourses]);
 
-    useEffect(() => {
-        if (user && user.wrapped) {
-            setDisplayWrapped(true);
-        } else {
-            setDisplayWrapped(false);
-        }
-    }, [user])
-
     const onSelectCourse = (course: FireCourse, addCourse: boolean) => {
         setSelectedCourses((previousSelectedCourses) => (
             addCourse

--- a/src/components/pages/SplitView.tsx
+++ b/src/components/pages/SplitView.tsx
@@ -120,14 +120,6 @@ const SplitView = ({
         updateSession(sessionHook);
     }, [sessionHook, updateSession]);
 
-    useEffect(() => {
-        if (user && user.wrapped) {
-            setDisplayWrapped(true);
-        } else {
-            setDisplayWrapped(false);
-        }
-    }, [user]);
-
     // Handle browser back button
     history.listen((location) => {
         setActiveView(


### PR DESCRIPTION
### Summary <!-- Required -->

Remove the useEffects that render Wrapped on entry

<!-- Provide a general summary of your changes in the Title above -->

<!-- Add your summary here -->

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->

<!-- Briefly describe how you test you changes. -->

QMI Wrapped doesn't keep appearing on reload anymore.