### PR TITLE
Calendar export redesign css fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,15 @@
 # dependencies
 node_modules
 
+# yarn files
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
+
 # testing
 /coverage
 

--- a/src/components/includes/CalendarSessionCard.tsx
+++ b/src/components/includes/CalendarSessionCard.tsx
@@ -15,6 +15,7 @@ const CalendarSessionCard = (props: {
     session: FireSession;
     callback: (sessionId: string) => void;
     active: boolean;
+    // eslint-disable-next-line react/no-unused-prop-types
     status: string;
     setIsDayExport: React.Dispatch<React.SetStateAction<boolean>>;
     setShowCalendarModal: React.Dispatch<React.SetStateAction<boolean>>;
@@ -84,22 +85,18 @@ const CalendarSessionCard = (props: {
 
             <div className='CalendarCard'>
                 <div className='Wrapper'>
-                <div className='Location'>
-                    {'building' in session ? (
-                        
+                    <div className='Location'>
+                        {'building' in session ? (
                             session.building + ' ' + session.room
-                        
-                    ) : session.modality === 'review' ? (
-                        'Zoom Discussion'
-                    ) : (
-                        'Online'
-                    )}
-                
-
+                        ) : session.modality === 'review' ? (
+                            'Zoom Discussion'
+                        ) : (
+                            'Online'
+                        )}
                         {numAhead > 0 && (<div className={'Indicator'}>
                             <div className='Circle' />
                         </div>)}
-                </div>
+                    </div>
 
                     <button
                         type="button"

--- a/src/components/includes/CalendarSessionCard.tsx
+++ b/src/components/includes/CalendarSessionCard.tsx
@@ -84,19 +84,22 @@ const CalendarSessionCard = (props: {
 
             <div className='CalendarCard'>
                 <div className='Wrapper'>
+                <div className='Location'>
                     {'building' in session ? (
-                        <div className='Location'>
-                            {session.building + ' ' + session.room}
-                        </div>
+                        
+                            session.building + ' ' + session.room
+                        
                     ) : session.modality === 'review' ? (
-                        <div className='Location'> Zoom Discussion </div>
+                        'Zoom Discussion'
                     ) : (
-                        <div className='Location'>Online</div>
+                        'Online'
                     )}
+                
 
-                    {numAhead > 0 && (<div className={'Indicator ' + props.status}>
-                        <div className='Circle' />
-                    </div>)}
+                        {numAhead > 0 && (<div className={'Indicator'}>
+                            <div className='Circle' />
+                        </div>)}
+                </div>
 
                     <button
                         type="button"

--- a/src/styles/MessageModal.scss
+++ b/src/styles/MessageModal.scss
@@ -106,7 +106,6 @@
       font-weight: 300;
       font-size: 18px;
       padding-top: 15px;
-      line-height: 0px;
     }
 
   }
@@ -213,7 +212,6 @@
 
   .CalendarExportModalVisible {
     width: 80%;
-    animation: 10s ease-in both modalFadeIn;
 
     .ExportText {
       font-size: 15px;
@@ -226,6 +224,10 @@
 
     .CalendarItem {
       width: 35%;
+    }
+
+    .content {
+      font-size:14px;
     }
   }
 }

--- a/src/styles/calendar/CalendarDaySelect.scss
+++ b/src/styles/calendar/CalendarDaySelect.scss
@@ -41,7 +41,9 @@ $red: #f67d7d;
     margin-left: -2px;
     height: 30px;
     width: 30px;
+    transition: background-color 0.3s;
 }
+
 
 .menuDate:focus {
     outline: 0;

--- a/src/styles/calendar/CalendarSessions.scss
+++ b/src/styles/calendar/CalendarSessions.scss
@@ -133,7 +133,6 @@ $open: #ffdba6;
         margin-left: 5px;
 
         .Circle {
-            border: solid 0.5px white;
             border-radius: 14px;
             height: 8.719px;
             width: 8.719px;

--- a/src/styles/calendar/CalendarSessions.scss
+++ b/src/styles/calendar/CalendarSessions.scss
@@ -130,6 +130,7 @@ $open: #ffdba6;
 
     .Indicator {
         margin-top: 6px;
+        margin-left: 5px;
 
         .Circle {
             border: solid 0.5px white;
@@ -173,6 +174,7 @@ $open: #ffdba6;
             font-size: 14px;
             font-weight: 500;
             width: 160px;
+            display: inline-flex;
         }
 
         .Tas {


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
Small css fixes for #862 , especially mobile view
- changed dot indicator to actually be red dot, not flash green when TA active
- removed long fadeIn time for mobile modal view
- adjust "export to gcal/ical" text font size for mobile view
- added hover effect to selecting calendar dates to match design prototypes

https://github.com/user-attachments/assets/56443c82-a067-446f-8e65-d456a1d77e5a

<!-- Add your summary here -->

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->

<!-- Briefly describe how you test you changes. -->
- red dot only appears for TAs, not students, instead of previously styled indicator when there is a question in the queue
- could test with more than one question if it still works
## Make sure this branch doesn't break anything for other devs with the gitignore additions

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
