### PR TITLE
Eric/Fixed Bug where Question Feedback Prompt is not displayed

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -510,11 +510,9 @@ exports.onQuestionStatusUpdate = functions.firestore
                     // Object with questionId, askerId, and resolvedAt fields
                     // questionId: the id of the question that was resolved
                     // askerId: the id of the user who asked the question
-                    // resolvedAt: the time the question was resolved
                     recentlyResolvedQuestion: {
                         questionId,
                         askerId: userId,
-                        resolvedAt: admin.firestore.Timestamp.now(),
                     }
                 });
         }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -503,11 +503,11 @@ exports.onQuestionStatusUpdate = functions.firestore
             // Retrieve the session document reference 
             const userDoc = db.doc(`users/${userId}`);
 
-            // Update the resolvedQuestionsArray field in the session document if it exists
+            // Update the resolvedQuestionsArray field in the user document if it exists
             return userDoc.update(
                 {
                     // Keeps track of the most recent question that was resolved
-                    // Object with questionId, askerId, and resolvedAt fields
+                    // Object with questionId and askerId fields
                     // questionId: the id of the question that was resolved
                     // askerId: the id of the user who asked the question
                     recentlyResolvedQuestion: {

--- a/src/components/types/fireData.d.ts
+++ b/src/components/types/fireData.d.ts
@@ -150,7 +150,6 @@ type FireCourseRole = "professor" | "ta" | "student";
 interface ResolvedItem {
     questionId: string;
     askerId: string;
-    resolvedAt: FireTimestamp;
 }
 
 /**


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
While implementing the function for this <a href="https://www.notion.so/1740ad723ce1817bb989e7d8329019ea?v=1740ad723ce181809fa7000c727ccc7e&p=1b90ad723ce180fea0eff8412b4004b9&pm=s"> ticket </a>, I realized a bug where although a prof/TA resolved a question, there was no question feedback prompts shown on the student side. I checked the firebase function loggers as shown below:
<img width="1469" alt="image" src="https://github.com/user-attachments/assets/caaf9869-8051-4aa2-9730-cdeb5c73500f" />
The user document was not successfully updated due to the invalid field `recentlyResolvedQuestion.resolvedAt`. This field is not necessary for the functionality of monitoring questions, and was intended to be used for debugging. This PR provides remedy for this issue by simply removing `resolvedAt` entirely. 

The updated version of the cloud function `onQuestionStatusUpdate` is already deployed to the test QMI firebase

<!-- Add your summary here -->

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->

<!-- Briefly describe how you test you changes. -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
