### PR TITLE
deployment analytics fix

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -30,7 +30,7 @@
       "yarn --cwd \"$RESOURCE_DIR\" build"
     ],
     "source": "functions",
-    "runtime": "nodejs16"
+    "runtime": "nodejs20"
   },
   "emulators": {
     "functions": {

--- a/src/components/pages/AdminView.tsx
+++ b/src/components/pages/AdminView.tsx
@@ -42,7 +42,8 @@ const AdminView = () => {
                 courseId="DUMMY_COURSE_ID"
             />
 
-            <h2><br />Queue Me In Product Analytics</h2>   
+            {/* Temporarily commenting out Analytics due to memory issues. */}
+            {/* <h2><br />Queue Me In Product Analytics</h2>   
                   
             {collapsed ? (
                 <Icon
@@ -59,7 +60,7 @@ const AdminView = () => {
                     />
                     <AnalyticsView/>
                 </div>
-            )}
+            )} */}
 
 
             <h2>Courses</h2>

--- a/src/components/pages/AdminView.tsx
+++ b/src/components/pages/AdminView.tsx
@@ -3,17 +3,17 @@ import { useHistory } from 'react-router'
 import { Grid } from '@material-ui/core'
 import { FormControl, Select, SelectChangeEvent, MenuItem, InputLabel } from '@mui/material';
 
-import { Icon } from 'semantic-ui-react'
+//import { Icon } from 'semantic-ui-react'
 import TopBar from '../includes/TopBar';
 import AdminCourseCard from '../includes/AdminCourseCard';
 import AdminCourseCreator from '../includes/AdminCourseCreator';
 import { useAllCourses, useIsAdmin } from '../../firehooks';
 import { CURRENT_SEMESTER, ALL_SEMESTERS } from '../../constants';
-import  AnalyticsView from './AnalyticsView';
+//import  AnalyticsView from './AnalyticsView';
 
 
 const AdminView = () => {
-    const [collapsed, setCollapsed] = useState(true);
+    //const [collapsed, setCollapsed] = useState(true);
     const history = useHistory();
     const courses = useAllCourses();
     const isAdmin = useIsAdmin();


### PR DESCRIPTION
### Summary <!-- Required -->

Trying to fix this error once deployed:
![Snapshot - 2025-23-4-23-25-04](https://github.com/user-attachments/assets/318d27d8-4e27-41b0-9c6c-deae177c1b38)


From this stackOverflow answer: https://stackoverflow.com/questions/65132937/firebaseerror-the-datastore-operation-timed-out
it is likely bc we are calling hooks for useAll--- which gets the *entire* collection which is probably too many reads.

We can see the reads have spiked in the graph too:
![image](https://github.com/user-attachments/assets/f2400543-3a71-4090-8c29-636a02738024)


<!-- Provide a general summary of your changes in the Title above -->

<!-- Add your summary here -->

<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sections, i.e. features, fixes, etc. -->

<!-- Add optional bullet points -->

### Test Plan <!-- Required -->

<!-- Briefly describe how you test you changes. -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes <!-- Optional -->

None

<!-- Uncomment any item below if it applies to your changes. -->

<!-- - Firebase schema change (requires migration plan)
<!-- - Firebase security policy change
<!-- - I updated existing types in `/src/components/types/`
<!-- - My changes requires a change to the documentation.
<!-- - Other change that could cause problems (Detailed in notes)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] My PR adds a @ts-ignore
